### PR TITLE
Adds fedora3 export script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,4 @@ spec/reports
 /spec/examples.txt
 node_modules
 .env.*
+public/

--- a/lib/fedora/MIGRATE_FEDORA3_OBJECTS_TUTORIAL.md
+++ b/lib/fedora/MIGRATE_FEDORA3_OBJECTS_TUTORIAL.md
@@ -1,0 +1,47 @@
+# Migrate Fedora 3 Objects Script
+
+This tool exports "datastreams" (binary or XML files) when provided with the Fedora instance information and a list of "PIDs" (IDs for each Fedora object). Please follow the directions below to get the script operating correctly.
+
+
+# Prerequisites
+
+The Migrate Fedora 3 Objects script relies on [Lyrasis' fedora-export CLI script](https://wiki.lyrasis.org/display/FEDORA38/fedora-export). Before running the Emory Library script, this suite of CLI tools must be installed in the computer or server that it will be executed from. Instructions on how to install the "client" level of CLI tools can be found [here](https://wiki.lyrasis.org/display/FEDORA38/Installation+and+Configuration). Please note that, since we only need the CLI scripts from this install, the only prerequisites needed for the installation are to have Java 8 installed, the environment variable of JAVA_HOME set to the home of JAVA 8's bin folder, the FEDORA_HOME environment variable set to where the client version of Fedora 3.8 is installed, and the computer or server's PATH to be updated as described in the installation instructions.
+
+The `dlp-selfdeposit` repository must also be cloned on any computer or server this is to be called from. And since this is a Ruby script, Ruby v3.2.2 must also be installed.
+
+# Usage
+
+When connected to Emory's VPN and working from the command line, change directories into the desired folder that you want the new folders of files to be created in. The script can be run with the following command:
+
+    ./lib/fedora/migrate_fedora3_objects.rb <list of pids separated only by commas> <Fedora 3 server's path with port number> <Fedora 3 API's username> <Fedora 3 API's password>
+Please note that the full path to the script must be used if intending to save the files anywhere besides the root folder of the `dlp-selfdeposit` Rails application.
+
+## List of PIDs
+
+When providing the script the PIDs from the Fedora 3 server, please omit the leading `emory:` prefix. These are standard for OpenEmory 1's objects, so providing them in the script would only make the command more difficult to create/edit. Please also separate the list of PIDs with a single comma only (no spaces please). For example:
+
+    q4fd0,fjhxt,dzmbk
+
+## Fedora 3 Server's Path
+
+The Fedora 3 server's path should match the format below:
+
+    http://www.example.com:8080
+
+Be aware that the current version of this script can only process exports from a `http` server. Working with `https` server requires the passing of a Java Certificate with the server communication, which isn't possible with this version.
+
+## Fedora 3 API's Username and Password
+
+The default username and password for Fedora API servers are both `fedoraAdmin`. Please try this first, and if you run into Authentication errors, please reach out to the Software Development for guidance.
+
+# Expected Results
+When all prerequisites are met, the script will report back with two lines, resembling
+
+    Exporting emory:XXXXX to ./emory_XXXXX.xml
+    Exported emory:XXXXX
+
+When the script fails, the terminal will display errors that can be reported to the Software Development for further guidance.
+
+If the script performs as expected, there should be a new XML file and folder in the directory you called the script from. The XML was used by the script to pull the needed files. This is left in this folder to help diagnose any unexpected behavior with the script. The new folder contains the files downloaded from the Fedora server. Each of the files (except AUDIT.xml) should be properly formatted and produce no errors when opened in a compatible application (XMLs can be opened in any web browser). The `AUDIT.xml` isn't processed in the same fashion as the other XMLs in the folder, so it needs to be opened in a text editor.
+
+Please report to Software Development any issues with the documents/binaries in the folder.

--- a/lib/fedora/migrate_fedora3_objects.rb
+++ b/lib/fedora/migrate_fedora3_objects.rb
@@ -1,0 +1,105 @@
+#!/usr/bin/env ruby
+require 'fileutils'
+require 'nokogiri'
+require 'open-uri'
+
+class MigrateFedoraThreeObjects
+  ALLOWED_TYPES = {
+  	'application/pdf': 'pdf',
+	'application/vnd.openxmlformats-officedocument.wordprocessingml.document': 'docx',
+	'application/msword': 'doc',
+	'application/vnd.openxmlformats-officedocument.presentationml.presentation': 'pptx',
+	'application/vnd.ms-powerpoint': 'ppt',
+	'image/jpeg': 'jpeg',
+	'image/tiff': 'tiff',
+	'image/png': 'png',
+	'application/vnd.ms-excel': 'xls',
+	'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': 'xlsx'
+  }
+
+  def initialize(pids:, fedora_three_path:, fedora_username:, fedora_password:)
+  	@pids = pids
+  	@fedora_three_path = fedora_three_path
+  	@fedora_username = fedora_username
+  	@fedora_password = fedora_password
+  end
+
+  def run
+  	pid_arr = @pids.split(',')
+
+  	pid_arr.each do |pid|
+  	  @pid = pid
+  	  make_pid_folder
+  	  @pid_xml = pull_pid_xml
+  	  copy_files_to_folder
+  	end
+  end
+
+  private
+
+  def make_pid_folder
+  	FileUtils.mkdir_p "emory_#{@pid}"
+  end
+
+  def pull_pid_xml
+  	system('fedora-export.sh', @fedora_three_path.split('://').last, @fedora_username, @fedora_password,
+  		   "emory:#{@pid}", 'info:fedora/fedora-system:FOXML-1.1', 'migrate', '.', @fedora_three_path.split('://').first)
+  	file = File.open("./emory_#{@pid}.xml")
+  	Nokogiri::XML(file)
+  end
+
+  def copy_files_to_folder
+  	@document_name = @pid_xml.at_xpath("//foxml:property[@NAME='info:fedora/fedora-system:def/model#label']")['VALUE']
+  	datastreams = @pid_xml.xpath('//foxml:datastream')
+
+  	datastreams.each do |datastream|
+  	  if datastream['ID'] == 'AUDIT'
+  	  	pull_audit_object(datastream:)
+  	  elsif test_for_xmls(datastream:)
+  	  	pull_xml_object(datastream:)
+  	  else
+  	  	pull_binary_object(datastream:)
+  	  end
+  	end
+  end
+
+  def test_for_xmls(datastream:)
+  	datastream['ID'] != 'AUDIT' && ['text/xml', 'application/rdf+xml'].include?(datastream.elements.first['MIMETYPE'])
+  end
+
+  def pull_audit_object(datastream:)
+  	IO.copy_stream(StringIO.new(datastream.at_xpath('//foxml:datastreamVersion/foxml:xmlContent').to_s), "./emory_#{@pid}/AUDIT.xml")
+  end
+
+  def pull_xml_object(datastream:)
+  	xml_doc = datastream['ID']
+  	download = URI.open("#{@fedora_three_path}/fedora/get/emory:#{@pid}/#{xml_doc}")
+
+	IO.copy_stream(download, "./emory_#{@pid}/#{download.base_uri.to_s.split('/')[-1]}.xml")
+  end
+
+  def pull_binary_object(datastream:)
+  	binary_id = datastream['ID']
+  	binary_filename = datastream.elements.first['LABEL']
+  	binary_ext = ALLOWED_TYPES[:"#{datastream.elements.first['MIMETYPE']}"]
+  	binary_save_name = binary_filename.empty? ? [@document_name, binary_ext].join('.') : binary_filename
+  	download = URI.open("#{@fedora_three_path}/fedora/get/emory:#{@pid}/#{binary_id}")
+
+  	IO.copy_stream(download, "./emory_#{@pid}/#{binary_save_name}")
+  end
+end
+
+if ARGV.length != 4
+  puts "Exiting -- This script must be in the following format:"
+  puts "./lib/fedora/migrate_fedora3_objects.rb <a list of pids separated by commas> <Fedora 3 path> <Fedora 3 username> <Fedora 3 password>"
+  puts "NOTES: pids must be entered without the 'emory:' substring and the Fedora path must follow the following format:"
+  puts "http://example.com:1234"
+  exit 1
+end
+
+pids = ARGV[0]
+fedora_three_path = ARGV[1]
+fedora_username = ARGV[2]
+fedora_password = ARGV[3]
+
+MigrateFedoraThreeObjects.new(pids:, fedora_three_path:, fedora_username:, fedora_password:).run

--- a/lib/fedora/migrate_fedora3_objects.rb
+++ b/lib/fedora/migrate_fedora3_objects.rb
@@ -5,87 +5,87 @@ require 'open-uri'
 
 class MigrateFedoraThreeObjects
   ALLOWED_TYPES = {
-  	'application/pdf': 'pdf',
-	'application/vnd.openxmlformats-officedocument.wordprocessingml.document': 'docx',
-	'application/msword': 'doc',
-	'application/vnd.openxmlformats-officedocument.presentationml.presentation': 'pptx',
-	'application/vnd.ms-powerpoint': 'ppt',
-	'image/jpeg': 'jpeg',
-	'image/tiff': 'tiff',
-	'image/png': 'png',
-	'application/vnd.ms-excel': 'xls',
-	'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': 'xlsx'
+  'application/pdf': 'pdf',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document': 'docx',
+  'application/msword': 'doc',
+  'application/vnd.openxmlformats-officedocument.presentationml.presentation': 'pptx',
+  'application/vnd.ms-powerpoint': 'ppt',
+  'image/jpeg': 'jpeg',
+  'image/tiff': 'tiff',
+  'image/png': 'png',
+  'application/vnd.ms-excel': 'xls',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': 'xlsx'
   }
 
   def initialize(pids:, fedora_three_path:, fedora_username:, fedora_password:)
-  	@pids = pids
-  	@fedora_three_path = fedora_three_path
-  	@fedora_username = fedora_username
-  	@fedora_password = fedora_password
+    @pids = pids
+    @fedora_three_path = fedora_three_path
+    @fedora_username = fedora_username
+    @fedora_password = fedora_password
   end
 
   def run
-  	pid_arr = @pids.split(',')
+    pid_arr = @pids.split(',')
 
-  	pid_arr.each do |pid|
-  	  @pid = pid
-  	  make_pid_folder
-  	  @pid_xml = pull_pid_xml
-  	  copy_files_to_folder
-  	end
+    pid_arr.each do |pid|
+      @pid = pid
+      make_pid_folder
+      @pid_xml = pull_pid_xml
+      copy_files_to_folder
+    end
   end
 
   private
 
   def make_pid_folder
-  	FileUtils.mkdir_p "emory_#{@pid}"
+    FileUtils.mkdir_p "emory_#{@pid}"
   end
 
   def pull_pid_xml
-  	system('fedora-export.sh', @fedora_three_path.split('://').last, @fedora_username, @fedora_password,
-  		   "emory:#{@pid}", 'info:fedora/fedora-system:FOXML-1.1', 'migrate', '.', @fedora_three_path.split('://').first)
-  	file = File.open("./emory_#{@pid}.xml")
-  	Nokogiri::XML(file)
+    system('fedora-export.sh', @fedora_three_path.split('://').last, @fedora_username, @fedora_password,
+           "emory:#{@pid}", 'info:fedora/fedora-system:FOXML-1.1', 'migrate', '.', @fedora_three_path.split('://').first)
+    file = File.open("./emory_#{@pid}.xml")
+    Nokogiri::XML(file)
   end
 
   def copy_files_to_folder
-  	@document_name = @pid_xml.at_xpath("//foxml:property[@NAME='info:fedora/fedora-system:def/model#label']")['VALUE']
-  	datastreams = @pid_xml.xpath('//foxml:datastream')
+    @document_name = @pid_xml.at_xpath("//foxml:property[@NAME='info:fedora/fedora-system:def/model#label']")['VALUE']
+    datastreams = @pid_xml.xpath('//foxml:datastream')
 
-  	datastreams.each do |datastream|
-  	  if datastream['ID'] == 'AUDIT'
-  	  	pull_audit_object(datastream:)
-  	  elsif test_for_xmls(datastream:)
-  	  	pull_xml_object(datastream:)
-  	  else
-  	  	pull_binary_object(datastream:)
-  	  end
-  	end
+    datastreams.each do |datastream|
+      if datastream['ID'] == 'AUDIT'
+         pull_audit_object(datastream:)
+      elsif test_for_xmls(datastream:)
+         pull_xml_object(datastream:)
+      else
+         pull_binary_object(datastream:)
+      end
+    end
   end
 
   def test_for_xmls(datastream:)
-  	datastream['ID'] != 'AUDIT' && ['text/xml', 'application/rdf+xml'].include?(datastream.elements.first['MIMETYPE'])
+    datastream['ID'] != 'AUDIT' && ['text/xml', 'application/rdf+xml'].include?(datastream.elements.first['MIMETYPE'])
   end
 
   def pull_audit_object(datastream:)
-  	IO.copy_stream(StringIO.new(datastream.at_xpath('//foxml:datastreamVersion/foxml:xmlContent').to_s), "./emory_#{@pid}/AUDIT.xml")
+    IO.copy_stream(StringIO.new(datastream.at_xpath('//foxml:datastreamVersion/foxml:xmlContent').to_s), "./emory_#{@pid}/AUDIT.xml")
   end
 
   def pull_xml_object(datastream:)
-  	xml_doc = datastream['ID']
-  	download = URI.open("#{@fedora_three_path}/fedora/get/emory:#{@pid}/#{xml_doc}")
+    xml_doc = datastream['ID']
+    download = URI.open("#{@fedora_three_path}/fedora/get/emory:#{@pid}/#{xml_doc}")
 
-	IO.copy_stream(download, "./emory_#{@pid}/#{download.base_uri.to_s.split('/')[-1]}.xml")
+    IO.copy_stream(download, "./emory_#{@pid}/#{download.base_uri.to_s.split('/')[-1]}.xml")
   end
 
   def pull_binary_object(datastream:)
-  	binary_id = datastream['ID']
-  	binary_filename = datastream.elements.first['LABEL']
-  	binary_ext = ALLOWED_TYPES[:"#{datastream.elements.first['MIMETYPE']}"]
-  	binary_save_name = binary_filename.empty? ? [@document_name, binary_ext].join('.') : binary_filename
-  	download = URI.open("#{@fedora_three_path}/fedora/get/emory:#{@pid}/#{binary_id}")
+    binary_id = datastream['ID']
+    binary_filename = datastream.elements.first['LABEL']
+    binary_ext = ALLOWED_TYPES[:"#{datastream.elements.first['MIMETYPE']}"]
+    binary_save_name = binary_filename.empty? ? [@document_name, binary_ext].join('.') : binary_filename
+    download = URI.open("#{@fedora_three_path}/fedora/get/emory:#{@pid}/#{binary_id}")
 
-  	IO.copy_stream(download, "./emory_#{@pid}/#{binary_save_name}")
+    IO.copy_stream(download, "./emory_#{@pid}/#{binary_save_name}")
   end
 end
 


### PR DESCRIPTION
- .gitignore: ignores `public` folder that should be locked after initial application setup.
- lib/fedora/MIGRATE_FEDORA3_OBJECTS_TUTORIAL.md: explains to user how to fire off script command.
- lib/fedora/migrate_fedora3_objects.rb: interacts with Lyrasis' `fedora-export` CLI tool to download binaries to a desired folder.