### PR TITLE
Adds holding_repository field.

### DIFF
--- a/app/views/records/edit_fields/_holding_repository.html.erb
+++ b/app/views/records/edit_fields/_holding_repository.html.erb
@@ -1,0 +1,8 @@
+<%=
+  f.input key,
+  input_html: {
+    class: 'form-control',
+    data: { 'autocomplete-url' => "/authorities/search/loc/names",
+      'autocomplete' => key }
+  } ,
+  required: f.object.required?(key) %>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -56,3 +56,7 @@ en:
     institution_name_full: The Institution Name
     product_name: DLP Self Deposit
     product_twitter_handle: ""
+  simple_form:
+    labels:
+      defaults:
+        holding_repository: Library

--- a/config/metadata/publication_metadata.yaml
+++ b/config/metadata/publication_metadata.yaml
@@ -125,6 +125,16 @@ attributes:
     index_keys:
       - 'grant_information_tesim'
     predicate: http://metadata.emory.edu/vocab/cor-terms#grantOrFundingNote
+  holding_repository:
+    type: string
+    multiple: false
+    form:
+      primary: true
+      required: true
+      multiple: false
+    index_keys:
+      - 'holding_repository_tesi'
+    predicate: http://id.loc.gov/vocabulary/relators/rps
   institution:
     type: string
     multiple: false


### PR DESCRIPTION
- app/views/records/edit_fields/_holding_repository.html.erb: brings over edit field code from curate.
- config/locales/hyrax.en.yml: converts label to `Library`.
- config/metadata/publication_metadata.yaml: adds field to the metatdata YAML.