### PR TITLE
Adds emory_content_type with controlled vocabulary.

### DIFF
--- a/app/services/self_deposit/content_types_service.rb
+++ b/app/services/self_deposit/content_types_service.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+module SelfDeposit
+  module ContentTypesService
+    mattr_accessor :authority
+    self.authority = Qa::Authorities::Local.subauthority_for('emory_content_types')
+
+    def self.select_options
+      authority.all.map do |element|
+        [element[:label], element[:id]]
+      end
+    end
+
+    def self.label(id)
+      authority.find(id).fetch('term')
+    end
+
+    ##
+    # @param [String, nil] id identifier of the resource type
+    #
+    # @return [String] a schema.org type. Gives the default type if `id` is nil.
+    def self.microdata_type(id)
+      return Hyrax.config.microdata_default_type if id.nil?
+      Microdata.fetch("resource_type.#{id}", default: Hyrax.config.microdata_default_type)
+    end
+  end
+end

--- a/app/views/records/edit_fields/_emory_content_type.html.erb
+++ b/app/views/records/edit_fields/_emory_content_type.html.erb
@@ -1,0 +1,4 @@
+<%= f.input :emory_content_type, as: :select,
+    collection: SelfDeposit::ContentTypesService.select_options,
+    include_blank: true, required: true,
+    input_html: { class: 'form-control', multiple: false } %>

--- a/config/authorities/emory_content_types.yml
+++ b/config/authorities/emory_content_types.yml
@@ -1,0 +1,46 @@
+terms:
+  - id: http://id.loc.gov/vocabulary/resourceTypes/art
+    term: Artifact
+    active: true
+  - id: http://id.loc.gov/vocabulary/resourceTypes/aud
+    term: Audio
+    active: true
+  - id: http://id.loc.gov/vocabulary/resourceTypes/car
+    term: Cartographic
+    active: true
+  - id: http://id.loc.gov/vocabulary/resourceTypes/col
+    term: Collection
+    active: true
+  - id: http://id.loc.gov/vocabulary/resourceTypes/dat
+    term: Dataset
+    active: true
+  - id: http://id.loc.gov/vocabulary/resourceTypes/dig
+    term: Digital
+    active: true
+  - id: http://id.loc.gov/vocabulary/resourceTypes/man
+    term: Manuscript
+    active: true
+  - id: http://id.loc.gov/vocabulary/resourceTypes/mix
+    term: Mixed material
+    active: true
+  - id: http://id.loc.gov/vocabulary/resourceTypes/mov
+    term: Moving image
+    active: true
+  - id: http://id.loc.gov/vocabulary/resourceTypes/mul
+    term: Multimedia
+    active: true
+  - id: http://id.loc.gov/vocabulary/resourceTypes/not
+    term: Notated music
+    active: true
+  - id: http://id.loc.gov/vocabulary/resourceTypes/img
+    term: Still image
+    active: true
+  - id: http://id.loc.gov/vocabulary/resourceTypes/tac
+    term: Tactile
+    active: true
+  - id: http://id.loc.gov/vocabulary/resourceTypes/txt
+    term: Text
+    active: true
+  - id: http://id.loc.gov/vocabulary/resourceTypes/unk
+    term: Unspecified
+    active: true

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -59,4 +59,5 @@ en:
   simple_form:
     labels:
       defaults:
+        emory_content_type: Format
         holding_repository: Library

--- a/config/metadata/publication_metadata.yaml
+++ b/config/metadata/publication_metadata.yaml
@@ -100,6 +100,16 @@ attributes:
     index_keys:
       - 'emory_ark_tesim'
     predicate: http://id.loc.gov/vocabulary/identifiers/local#ark
+  emory_content_type:
+    type: string
+    multiple: false
+    form:
+      primary: true
+      required: true
+      multiple: false
+    index_keys:
+      - 'emory_content_type_tesi'
+    predicate: http://metadata.emory.edu/vocab/predicates#contentType
   final_published_versions:
     type: string
     multiple: true


### PR DESCRIPTION
- app/services/self_deposit/content_types_service.rb: creates service that scrapes a YAML file for options.
- app/views/records/edit_fields/_emory_content_type.html.erb: replaces default partial to transform field into a select.
- config/authorities/emory_content_types.yml: copies over Curate's resource_types to provide options to `emory_content_type`.
- config/locales/hyrax.en.yml: changes label to Curate's `Format`.
- config/metadata/publication_metadata.yaml: generates `emory_content_type` field with same properties as Curate.