### PR TITLE
Adds our customization to language field.

### DIFF
--- a/app/forms/publication_form.rb
+++ b/app/forms/publication_form.rb
@@ -6,7 +6,7 @@
 # @see https://github.com/samvera/hyrax/wiki/Hyrax-Valkyrie-Usage-Guide#forms
 # @see https://github.com/samvera/valkyrie/wiki/ChangeSets-and-Dirty-Tracking
 class PublicationForm < Hyrax::Forms::PcdmObjectForm(Publication)
-  include Hyrax::FormFields(:basic_metadata)
+  include Hyrax::FormFields(:emory_basic_metadata)
   include Hyrax::FormFields(:publication_metadata)
 
   # Define custom form fields using the Valkyrie::ChangeSet interface

--- a/app/indexers/publication_indexer.rb
+++ b/app/indexers/publication_indexer.rb
@@ -3,7 +3,7 @@
 # Generated via
 #  `rails generate hyrax:work_resource Publication`
 class PublicationIndexer < Hyrax::Indexers::PcdmObjectIndexer(Publication)
-  include Hyrax::Indexer(:basic_metadata)
+  include Hyrax::Indexer(:emory_basic_metadata)
   include Hyrax::Indexer(:publication_metadata)
 
   # Uncomment this block if you want to add custom indexing behavior:

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -3,6 +3,6 @@
 # Generated via
 #  `rails generate hyrax:work_resource Publication`
 class Publication < Hyrax::Work
-  include Hyrax::Schema(:basic_metadata)
+  include Hyrax::Schema(:emory_basic_metadata)
   include Hyrax::Schema(:publication_metadata)
 end

--- a/app/views/records/edit_fields/_language.html.erb
+++ b/app/views/records/edit_fields/_language.html.erb
@@ -1,0 +1,8 @@
+<%=
+  f.input key,
+  input_html: {
+    class: 'form-control',
+    data: { 'autocomplete-url' => "/authorities/search/loc/iso639-2",
+      'autocomplete' => key }
+  } ,
+  required: f.object.required?(key) %>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -57,6 +57,10 @@ en:
     product_name: DLP Self Deposit
     product_twitter_handle: ""
   simple_form:
+    hints:
+      defaults:
+        language: ''
     labels:
       defaults:
         holding_repository: Library
+        language: Primary Language

--- a/config/metadata/emory_basic_metadata.yaml
+++ b/config/metadata/emory_basic_metadata.yaml
@@ -1,0 +1,195 @@
+# Override of basic_metadata.yaml in Hyrax v5.0.0.rc3
+#   Please be very careful in the changes made to this document.
+#   Generally, it is safe to alter the form options here (please
+#   match the "multiple" settings to the field level, which should
+#   never change).
+#   Altering "primary" and "required" within the form options will
+#   only affect how the form is built, which really doesn't affect
+#   persistence like the other settings.
+#
+# What has been changed:
+#   -`language` has been made a "primary" field (brings it out of
+#      "Additional Fields").
+---
+attributes:
+  abstract:
+    type: string
+    multiple: true
+    form:
+      primary: false
+    index_keys:
+      - "abstract_tesim"
+    predicate: http://purl.org/dc/terms/abstract
+  access_right:
+    type: string
+    multiple: true
+    form:
+      primary: false
+    index_keys:
+      - "access_right_tesim"
+    predicate: http://purl.org/dc/terms/accessRights
+  alternative_title:
+    type: string
+    multiple: true
+    form:
+      primary: false
+    index_keys:
+      - "alternative_title_tesim"
+    predicate: http://purl.org/dc/terms/alternative
+  arkivo_checksum:
+    type: string
+    multiple: false
+    form:
+      primary: false
+    predicate: http://scholarsphere.psu.edu/ns#arkivoChecksum
+  based_near:
+    type: string
+    multiple: true
+    form:
+      primary: false
+    index_keys:
+      - "based_near_sim"
+      - "based_near_tesim"
+    predicate: http://xmlns.com/foaf/0.1/based_near
+  bibliographic_citation:
+    type: string
+    multiple: true
+    predicate: http://purl.org/dc/terms/bibliographicCitation
+  contributor:
+    type: string
+    multiple: true
+    form:
+      primary: false
+    index_keys:
+      - "contributor_tesim"
+      - "contributor_sim"
+    predicate: http://purl.org/dc/elements/1.1/contributor
+  creator:
+    type: string
+    multiple: true
+    form:
+      required: true
+      primary: true
+    index_keys:
+      - "creator_tesim"
+    predicate: http://purl.org/dc/elements/1.1/creator
+  date_created:
+    type: date_time
+    multiple: true
+    form:
+      primary: false
+    index_keys:
+      - "date_created_tesim"
+    predicate: http://purl.org/dc/terms/created
+  description:
+    type: string
+    multiple: true
+    form:
+      primary: false
+    index_keys:
+      - "description_tesim"
+    predicate: http://purl.org/dc/elements/1.1/description
+  identifier:
+    type: string
+    multiple: true
+    form:
+      primary: false
+    index_keys:
+      - "identifier_tesim"
+    predicate: http://purl.org/dc/terms/identifier
+  import_url:
+    type: string
+    predicate: http://scholarsphere.psu.edu/ns#importUrl
+  keyword:
+    type: string
+    multiple: true
+    index_keys:
+      - "keyword_sim"
+      - "keyword_tesim"
+    form:
+      primary: false
+    predicate: http://schema.org/keywords
+  publisher:
+    type: string
+    multiple: true
+    form:
+      primary: false
+    index_keys:
+      - "publisher_tesim"
+    predicate: http://purl.org/dc/elements/1.1/publisher
+  label:
+    type: string
+    form:
+      primary: false
+    index_keys:
+      - "label_tesim"
+    predicate: info:fedora/fedora-system:def/model#downloadFilename
+  language:
+    type: string
+    multiple: true
+    form:
+      primary: true
+    index_keys:
+      - "language_tesim"
+    predicate: http://purl.org/dc/elements/1.1/language
+  license:
+    type: string
+    multiple: true
+    form:
+      primary: false
+    index_keys:
+      - "license_tesim"
+    predicate: http://purl.org/dc/terms/license
+  relative_path:
+    type: string
+    predicate: http://scholarsphere.psu.edu/ns#relativePath
+  related_url:
+    type: string
+    multiple: true
+    form:
+      primary: false
+    index_keys:
+      - "related_url_tesim"
+    predicate: http://www.w3.org/2000/01/rdf-schema#seeAlso
+  resource_type:
+    type: string
+    multiple: true
+    form:
+      primary: false
+    index_keys:
+      - "resource_type_sim"
+      - "resource_type_tesim"
+    predicate: http://purl.org/dc/terms/type
+  rights_notes:
+    type: string
+    multiple: true
+    form:
+      primary: false
+    index_keys:
+      - "rights_notes_tesim"
+    predicate: http://purl.org/dc/elements/1.1/rights
+  rights_statement:
+    type: string
+    multiple: true
+    form:
+      primary: true
+    index_keys:
+      - "rights_statement_tesim"
+    predicate: http://www.europeana.eu/schemas/edm/rights
+  source:
+    type: string
+    multiple: true
+    form:
+      primary: false
+    index_keys:
+      - "source_tesim"
+    predicate: http://purl.org/dc/terms/source
+  subject:
+    type: string
+    multiple: true
+    index_keys:
+      - "subject_sim"
+      - "subject_tesim"
+    form:
+      primary: false
+    predicate: http://purl.org/dc/elements/1.1/subject


### PR DESCRIPTION
- app/forms/publication_form.rb, app/indexers/publication_indexer.rb, app/models/publication.rb: swaps out metadata YAML to our own so we can **_lighty_** customize the required metadata.
- app/views/records/edit_fields/_language.html.erb: points our language autocomplete to our approved vocabulary.
- config/locales/hyrax.en.yml: corrects our labels.
- config/metadata/emory_basic_metadata.yaml: overrides the `basic_metadata.yaml` to allow us to move fieds in and out of the collapsible.

Please note: this field is affected by this bug: https://github.com/emory-libraries/dlp-selfdeposit/issues/68