### PR TITLE
Adds controlled vocabulary to publisher_version field.

### DIFF
--- a/app/services/self_deposit/publisher_version_service.rb
+++ b/app/services/self_deposit/publisher_version_service.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module SelfDeposit
+  class PublisherVersionService < ::Hyrax::QaSelectService
+    def initialize
+      super('publisher_version')
+    end
+  end
+end

--- a/app/views/records/edit_fields/_publisher_version.html.erb
+++ b/app/views/records/edit_fields/_publisher_version.html.erb
@@ -1,0 +1,7 @@
+<% publisher_version = SelfDeposit::PublisherVersionService.new %>
+
+<%= f.input :publisher_version, as: :select,
+    collection: publisher_version.select_active_options,
+    include_blank: true, required: false,
+    item_helper: publisher_version.method(:include_current_value),
+    input_html: { class: 'form-control' } %>

--- a/config/authorities/publisher_version.yml
+++ b/config/authorities/publisher_version.yml
@@ -1,0 +1,7 @@
+terms:
+    - id: Preprint, Prior to Peer Review
+      term: Preprint, Prior to Peer Review
+    - id: Post-print, After Peer Review
+      term: Post-print, After Peer Review
+    - id: Final Publisher PDF
+      term: Final Publisher PDF


### PR DESCRIPTION
- app/services/self_deposit/publisher_version_service.rb: inherits general vocabulary logic from `::Hyrax::QaSelectService`. 
- app/views/records/edit_fields/_publisher_version.html.erb: brings over the select code from Curate's same field.
- config/authorities/publisher_version.yml: imports the same options from Curate.