### PR TITLE
Adds controlled vocabulary to data_classifications field.

### DIFF
--- a/app/services/self_deposit/data_classifications_service.rb
+++ b/app/services/self_deposit/data_classifications_service.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module SelfDeposit
+  class DataClassificationsService < ::Hyrax::QaSelectService
+    def initialize
+      super('data_classifications')
+    end
+  end
+end

--- a/app/views/records/edit_fields/_data_classifications.html.erb
+++ b/app/views/records/edit_fields/_data_classifications.html.erb
@@ -1,0 +1,7 @@
+<% data_classifications_service = SelfDeposit::DataClassificationsService.new %>
+
+<%= f.input :data_classifications, as: :multi_value_select,
+    collection: data_classifications_service.select_active_options,
+    include_blank: true, required: true,
+    item_helper: data_classifications_service.method(:include_current_value),
+    input_html: { class: 'form-control' } %>

--- a/config/authorities/data_classifications.yml
+++ b/config/authorities/data_classifications.yml
@@ -1,0 +1,13 @@
+terms:
+    - id: Public
+      term: Public
+      active: true
+    - id: Internal
+      term: Internal
+      active: true
+    - id: Confidential
+      term: Confidential
+      active: true
+    - id: Restricted
+      term: Restricted
+      active: true

--- a/config/metadata/publication_metadata.yaml
+++ b/config/metadata/publication_metadata.yaml
@@ -60,6 +60,7 @@ attributes:
     multiple: true
     form:
       primary: true
+      required: true
     index_keys:
       - 'data_classifications_tesim'
     predicate: http://metadata.emory.edu/vocab/cor-terms#dataClassification


### PR DESCRIPTION
- app/services/self_deposit/data_classifications_service.rb: creates a service to deliver our controlled vocabulary.
- app/views/records/edit_fields/_data_classifications.html.erb: brings over Curate html for select element.
- config/authorities/data_classifications.yml: copies over Curate options.
- config/metadata/publication_metadata.yaml: makes `data_classifications` a required form field.