### PR TITLE
Adds controlled vocabulary to content_genres field.

### DIFF
--- a/app/services/self_deposit/content_genres_service.rb
+++ b/app/services/self_deposit/content_genres_service.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module SelfDeposit
+  class ContentGenresService < ::Hyrax::QaSelectService
+    def initialize
+      super('content_genres')
+    end
+  end
+end

--- a/app/views/records/edit_fields/_content_genres.html.erb
+++ b/app/views/records/edit_fields/_content_genres.html.erb
@@ -1,0 +1,7 @@
+<% content_genres_service = SelfDeposit::ContentGenresService.new %>
+
+<%= f.input :content_genres, as: :multi_value_select,
+    collection: content_genres_service.select_active_options,
+    include_blank: true, required: false,
+    item_helper: content_genres_service.method(:include_current_value),
+    input_html: { class: 'form-control' } %>

--- a/config/authorities/content_genres.yml
+++ b/config/authorities/content_genres.yml
@@ -1,0 +1,22 @@
+terms:
+    - id: Article
+      term: Article
+      active: true
+    - id: Book
+      term: Book
+      active: true
+    - id: Book Chapter
+      term: Book Chapter
+      active: true
+    - id: Conference Paper
+      term: Conference Paper
+      active: true
+    - id: Poster
+      term: Poster
+      active: true
+    - id: Presentation
+      term: Presentation
+      active: true
+    - id: Report
+      term: Report
+      active: true


### PR DESCRIPTION
- app/services/self_deposit/content_genres_service.rb: creates controlled vocabulary service for `content_genres`.
- app/views/records/edit_fields/_content_genres.html.erb: overrides default input field for a multi-valued select that uses the above service for options.
- config/authorities/content_genres.yml: adds YAML that feeds the service.