### PR TITLE
Adds PreservationEvents to Publications.

### DIFF
--- a/app/controllers/hyrax/publications_controller.rb
+++ b/app/controllers/hyrax/publications_controller.rb
@@ -2,16 +2,73 @@
 
 # Generated via
 #  `rails generate hyrax:work_resource Publication`
+require './lib/preservation_events'
 module Hyrax
   # Generated controller for Publication
   class PublicationsController < ApplicationController
     # Adds Hyrax behaviors to the controller.
     include Hyrax::WorksControllerBehavior
     include Hyrax::BreadcrumbsForWorks
+    include ::PreservationEvents
     self.curation_concern_type = ::Publication
 
     # Use a Valkyrie aware form service to generate Valkyrie::ChangeSet style
     # forms.
     self.work_form_service = Hyrax::FormFactory.new
+
+    private
+
+    ##
+    # Hyrax v5.0.0 Override - inserts PreservationEvents if Publication is created successfully.
+    # @return [#errors]
+    # rubocop:disable Metrics/MethodLength
+    def create_valkyrie_work
+      @event_start = DateTime.current # record event_start timestamp
+      form = build_form
+      action = create_valkyrie_work_action.new(form: form,
+                                               transactions: transactions,
+                                               user: current_user,
+                                               params: params,
+                                               work_attributes_key: hash_key_for_curation_concern)
+
+      return after_create_error(form_err_msg(action.form), action.work_attributes) unless action.validate
+
+      result = action.perform
+
+      @curation_concern = result.value_or { return after_create_error(transaction_err_msg(result)) }
+      create_preservation_event(@curation_concern, work_creation)
+      create_preservation_event(@curation_concern, work_policy)
+      after_create_response
+    end
+    # rubocop:enable Metrics/MethodLength
+
+    def update_valkyrie_work
+      form = build_form
+      return after_update_error(form_err_msg(form)) unless form.validate(params[hash_key_for_curation_concern])
+      result =
+        transactions['change_set.update_work']
+        .with_step_args('work_resource.add_file_sets' => { uploaded_files: uploaded_files, file_set_params: params[hash_key_for_curation_concern][:file_set] },
+                        'work_resource.update_work_members' => { work_members_attributes: work_members_attributes },
+                        'work_resource.save_acl' => { permissions_params: form.input_params["permissions"] })
+        .call(form)
+      @curation_concern = result.value_or { return after_update_error(transaction_err_msg(result)) }
+      create_preservation_event(@curation_concern, work_update)
+      after_update_response
+    end
+
+    def work_creation
+      { 'type' => 'Validation', 'start' => @event_start, 'outcome' => 'Success', 'details' => 'Submission package validated',
+        'software_version' => 'SelfDeposit pre', 'user' => current_user.email }
+    end
+
+    def work_policy
+      { 'type' => 'Policy Assignment', 'start' => @event_start, 'outcome' => 'Success', 'software_version' => 'SelfDeposit pre',
+        'details' => "Visibility/access controls assigned: #{@curation_concern.visibility}", 'user' => current_user.email }
+    end
+
+    def work_update
+      { 'type' => 'Modification', 'start' => @event_start, 'outcome' => 'Success', 'details' => 'Object updated',
+        'software_version' => 'SelfDeposit pre', 'user' => current_user.email }
+    end
   end
 end

--- a/app/controllers/hyrax/publications_controller.rb
+++ b/app/controllers/hyrax/publications_controller.rb
@@ -25,10 +25,10 @@ module Hyrax
     def create_valkyrie_work
       @event_start = DateTime.current # record event_start timestamp
       form = build_form
-      action = create_valkyrie_work_action.new(form: form,
-                                               transactions: transactions,
+      action = create_valkyrie_work_action.new(form:,
+                                               transactions:,
                                                user: current_user,
-                                               params: params,
+                                               params:,
                                                work_attributes_key: hash_key_for_curation_concern)
 
       return after_create_error(form_err_msg(action.form), action.work_attributes) unless action.validate
@@ -48,8 +48,8 @@ module Hyrax
       return after_update_error(form_err_msg(form)) unless form.validate(params[hash_key_for_curation_concern])
       result =
         transactions['change_set.update_work']
-        .with_step_args('work_resource.add_file_sets' => { uploaded_files: uploaded_files, file_set_params: params[hash_key_for_curation_concern][:file_set] },
-                        'work_resource.update_work_members' => { work_members_attributes: work_members_attributes },
+        .with_step_args('work_resource.add_file_sets' => { uploaded_files:, file_set_params: params[hash_key_for_curation_concern][:file_set] },
+                        'work_resource.update_work_members' => { work_members_attributes: },
                         'work_resource.save_acl' => { permissions_params: form.input_params["permissions"] })
         .call(form)
       @curation_concern = result.value_or { return after_update_error(transaction_err_msg(result)) }

--- a/app/controllers/hyrax/publications_controller.rb
+++ b/app/controllers/hyrax/publications_controller.rb
@@ -42,6 +42,7 @@ module Hyrax
     end
     # rubocop:enable Metrics/MethodLength
 
+    # Hyrax v5.0.0 Override - inserts PreservationEvents if Publication is updated successfully.
     def update_valkyrie_work
       form = build_form
       return after_update_error(form_err_msg(form)) unless form.validate(params[hash_key_for_curation_concern])

--- a/app/models/preservation_event.rb
+++ b/app/models/preservation_event.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class PreservationEvent < Valkyrie::Resource
+  include Hyrax::Schema(:preservation_event_metadata)
+
+  def preservation_event_terms
+    attributes_map = { 'event_details' => event_details,
+                       'event_end' => event_end,
+                       'event_start' => event_start,
+                       'event_type' => event_type,
+                       'initiating_user' => initiating_user,
+                       'outcome' => outcome,
+                       'software_version' => software_version }
+    attributes_map.to_json
+  end
+
+  def failed_event_json
+    { "event_details" => event_details, "event_start" => event_start }.to_json
+  end
+end

--- a/app/models/preservation_workflow.rb
+++ b/app/models/preservation_workflow.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class PreservationWorkflow < Valkyrie::Resource
+  include Hyrax::Schema(:preservation_workflow_metadata)
+
+  def preservation_terms
+    attributes_map = { 'workflow_type' => workflow_type,
+                       'workflow_notes' => workflow_notes,
+                       'workflow_rights_basis' => workflow_rights_basis,
+                       'workflow_rights_basis_note' => workflow_rights_basis_note,
+                       'workflow_rights_basis_date' => workflow_rights_basis_date,
+                       'workflow_rights_basis_reviewer' => workflow_rights_basis_reviewer,
+                       'workflow_rights_basis_uri' => workflow_rights_basis_uri }
+    attributes_map.to_json
+  end
+end

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -10,12 +10,12 @@ class Publication < Hyrax::Work
     raise TypeError "can't convert #{event.class} into PreservationEvent" unless event.is_a? PreservationEvent
 
     self.preservation_event_ids =
-      self.preservation_event_ids.present? ? [self.preservation_event_ids, event.id.to_s].join(',') : event.id.to_s
+      preservation_event_ids.present? ? [preservation_event_ids, event.id.to_s].join(',') : event.id.to_s
   end
 
   def preservation_events
-    if self.preservation_event_ids.present?
-      self.preservation_event_ids.split(',').map { |id| Hyrax.query_service.find_by(id: id) }
+    if preservation_event_ids.present?
+      preservation_event_ids.split(',').map { |id| Hyrax.query_service.find_by(id:) }
     else
       []
     end

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -5,4 +5,19 @@
 class Publication < Hyrax::Work
   include Hyrax::Schema(:emory_basic_metadata)
   include Hyrax::Schema(:publication_metadata)
+
+  def add_preservation_event(event)
+    raise TypeError "can't convert #{event.class} into PreservationEvent" unless event.is_a? PreservationEvent
+
+    self.preservation_event_ids =
+      self.preservation_event_ids.present? ? [self.preservation_event_ids, event.id.to_s].join(',') : event.id.to_s
+  end
+
+  def preservation_events
+    if self.preservation_event_ids.present?
+      self.preservation_event_ids.split(',').map { |id| Hyrax.query_service.find_by(id: id) }
+    else
+      []
+    end
+  end
 end

--- a/config/metadata/preservation_event_metadata.yaml
+++ b/config/metadata/preservation_event_metadata.yaml
@@ -1,0 +1,31 @@
+attributes:
+  event_details:
+    type: string
+    predicate: http://metadata.emory.edu/vocab/cor-terms#eventDetails
+  event_end:
+    type: date_time
+    predicate: http://metadata.emory.edu/vocab/cor-terms#eventEnd
+  event_id:
+    type: string
+    predicate: http://metadata.emory.edu/vocab/cor-terms#eventIdentifier
+  event_start:
+    type: date_time
+    predicate: http://metadata.emory.edu/vocab/cor-terms#eventStart
+  event_type:
+    type: string
+    predicate: http://metadata.emory.edu/vocab/cor-terms#eventType
+  fileset_id:
+    type: string
+    predicate: http://metadata.emory.edu/vocab/cor-terms#filesetRelatedObject
+  initiating_user:
+    type: string
+    predicate: http://metadata.emory.edu/vocab/cor-terms#eventUser
+  outcome:
+    type: string
+    predicate: http://metadata.emory.edu/vocab/cor-terms#eventOutcome
+  software_version:
+    type: string
+    predicate: http://metadata.emory.edu/vocab/cor-terms#softwareVersion
+  workflow_id:
+    type: string
+    predicate: http://metadata.emory.edu/vocab/cor-terms#workflowRelatedObject

--- a/config/metadata/preservation_workflow_metadata.yaml
+++ b/config/metadata/preservation_workflow_metadata.yaml
@@ -1,0 +1,23 @@
+attributes:
+  workflow_type:
+    type: string
+    predicate: http://metadata.emory.edu/vocab/cor-terms#workflowType
+  workflow_notes:
+    type: string
+    predicate: http://metadata.emory.edu/vocab/cor-terms#workflowNote
+  workflow_rights_basis:
+    type: string
+    predicate: http://metadata.emory.edu/vocab/cor-terms#workflowRightsBasis
+  workflow_rights_basis_note:
+    type: string
+    predicate: http://metadata.emory.edu/vocab/cor-terms#workflowRightsBasisNote
+  workflow_rights_basis_date:
+    type: date_time
+    predicate: http://metadata.emory.edu/vocab/cor-terms#workflowRightsBasisDate
+  workflow_rights_basis_reviewer:
+    type: string
+    predicate: http://metadata.emory.edu/vocab/cor-terms#workflowRightsBasisReviewer
+  workflow_rights_basis_uri:
+    type: string
+    predicate: http://metadata.emory.edu/vocab/cor-terms#workflowRightsBasisURI
+

--- a/config/metadata/publication_metadata.yaml
+++ b/config/metadata/publication_metadata.yaml
@@ -227,6 +227,9 @@ attributes:
     index_keys:
       - 'place_of_production_tesi'
     predicate: http://id.loc.gov/vocabulary/relators/pup
+  preservation_event_ids:
+    type: string
+    predicate: http://metadata.emory.edu/vocab/cor-terms#preservationEventIDs
   publisher_version:
     type: string
     multiple: false

--- a/lib/preservation_events.rb
+++ b/lib/preservation_events.rb
@@ -8,12 +8,12 @@ module PreservationEvents
   def create_preservation_event(object, event)
     persister = Hyrax.persister
     event = PreservationEvent.new(
-      event_details:    event['details'],
-      event_end:        event['end'] || DateTime.current,
-      event_start:      event['start'],
-      event_type:       event['type'],
-      initiating_user:  event['user'],
-      outcome:          event['outcome'],
+      event_details: event['details'],
+      event_end: event['end'] || DateTime.current,
+      event_start: event['start'],
+      event_type: event['type'],
+      initiating_user: event['user'],
+      outcome: event['outcome'],
       software_version: event['software_version']
     )
 

--- a/lib/preservation_events.rb
+++ b/lib/preservation_events.rb
@@ -20,5 +20,6 @@ module PreservationEvents
     event = persister.save(resource: event)
     object.add_preservation_event(event)
     persister.save(resource: object)
+    event
   end
 end

--- a/lib/preservation_events.rb
+++ b/lib/preservation_events.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# This module will be used to define preservation_event
+# methods for work and fileset
+module PreservationEvents
+  # @param object - work or file_set object
+  # @param event - hash with all event requirements (details, start, type, user, outcome, software_version)
+  def create_preservation_event(object, event)
+    persister = Hyrax.persister
+    event = PreservationEvent.new(
+      event_details:    event['details'],
+      event_end:        event['end'] || DateTime.current,
+      event_start:      event['start'],
+      event_type:       event['type'],
+      initiating_user:  event['user'],
+      outcome:          event['outcome'],
+      software_version: event['software_version']
+    )
+
+    event = persister.save(resource: event)
+    object.add_preservation_event(event)
+    persister.save(resource: object)
+  end
+end

--- a/spec/lib/preservation_events_spec.rb
+++ b/spec/lib/preservation_events_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require './lib/preservation_events'
+include PreservationEvents
+
+RSpec.describe PreservationEvents, :clean do
+  let(:work) do
+    work = Publication.new(
+      data_classification: 'Public',
+      deduplication_key: '123456',
+      emory_content_type: 'Manuscript',
+      holding_repository: 'Emory Libraries',
+      creator: 'Dr. Seuss',
+      rights_statement: 'http://rightsstatements.org/vocab/NoC-NC/1.0/'
+    )
+
+    Hyrax.persister.save(resource: work)
+  end
+
+  let(:start) { 1.day.ago }
+  let(:end_time) { 10.minutes.ago }
+  let(:event) do
+    { 'type' => 'Policy Assignment', 'start' => start, 'end' => end_time,
+      'details' => "Visibility/access controls assigned: Emory Network",
+      'software_version' => 'SelfDeposit 1.0', 'user' => 'admin@example.com',
+      'outcome' => 'Success' }
+  end
+  let(:saved_event) { create_preservation_event(work, event) }
+  let(:queried_work) { Hyrax.query_service.find_by(id: work.id) }
+
+  context '#create_preservation_event' do
+    it 'returns a persisted PreservationEvent' do
+      expect(saved_event).to be_a PreservationEvent
+      expect(saved_event).to be_persisted
+    end
+
+    it 'adds PreservationEvent id to work attribute #preservation_event_ids' do
+      saved_event
+
+      expect(queried_work.preservation_event_ids).to eq saved_event.id
+    end
+  end
+end

--- a/spec/models/preservation_event_spec.rb
+++ b/spec/models/preservation_event_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PreservationEvent do
+  context "a new workflow" do
+    let(:adapter)       { Valkyrie::MetadataAdapter.find(:test_adapter) }
+    let(:persister)     { adapter.persister }
+    let(:query_service) { adapter.query_service }
+    let(:preservation_event) { described_class.new }
+
+    let(:event_id) { 'wecpo-cwemclk-cvrroi' }
+    let(:event_type) { "type" }
+    let(:initiating_user) { "default user" }
+    let(:event_start) { "2010-02-02" }
+    let(:event_end) { "2010-02-03" }
+    let(:outcome) { "passed" }
+    let(:fileset_id) { "1232gfbad2221-cor" }
+    let(:software_version) { "ClamXav 2.1.7" }
+    let(:workflow_id) { "ewfmlkme-12312-cadcnel" }
+    let(:event_details) { "special details" }
+
+    it "can set a event_id" do
+      preservation_event.event_id = event_id
+      expect(preservation_event.event_id).to eq event_id
+    end
+
+    it "can set a event type" do
+      preservation_event.event_type = event_type
+      expect(preservation_event.event_type).to eq event_type
+    end
+
+    it "can set a initiating user" do
+      preservation_event.initiating_user = initiating_user
+      expect(preservation_event.initiating_user).to eq initiating_user
+    end
+
+    it "can set an event start" do
+      preservation_event.event_start = event_start
+      expect(preservation_event.event_start).to eq event_start
+    end
+
+    it "can set an event end" do
+      preservation_event.event_end = event_end
+      expect(preservation_event.event_end).to eq event_end
+    end
+
+    it "can set an outcome" do
+      preservation_event.outcome = outcome
+      expect(preservation_event.outcome).to eq outcome
+    end
+
+    it "can set a fileset id" do
+      preservation_event.fileset_id = fileset_id
+      expect(preservation_event.fileset_id).to eq fileset_id
+    end
+
+    it "can set a software version" do
+      preservation_event.software_version = software_version
+      expect(preservation_event.software_version).to eq software_version
+    end
+
+    it "can set a workflow id" do
+      preservation_event.workflow_id = workflow_id
+      expect(preservation_event.workflow_id).to eq workflow_id
+    end
+
+    it "can set event details" do
+      preservation_event.event_details = event_details
+      expect(preservation_event.event_details).to eq event_details
+    end
+
+    context 'class methods' do
+      let(:different_event_start) { DateTime.current.strftime('%FT%T%:z') }
+      let(:preservation_event) do
+        event = described_class.new(
+          event_type:       event_type,
+          initiating_user:  initiating_user,
+          event_start:      different_event_start,
+          event_end:        event_end,
+          outcome:          outcome,
+          software_version: software_version,
+          event_details:    event_details
+        )
+
+        persister.save(resource: event)
+      end
+
+      describe '#preservation_event_terms' do
+        it 'creates a hash of preservation_event key/values in json' do
+          expect(preservation_event.preservation_event_terms).to eq(
+            "{\"event_details\":\"#{event_details}\",\"event_end\":\"#{event_end}\",\"event_start\":\"#{different_event_start}\",\"event_type\":\"#{event_type}\"" \
+            ",\"initiating_user\":\"#{initiating_user}\",\"outcome\":\"#{outcome}\",\"software_version\":\"#{software_version}\"}"
+          )
+        end
+      end
+
+      describe '#failed_event_json' do
+        it 'creates a hash of needed key/values for failed events in json' do
+          expect(preservation_event.failed_event_json).to eq(
+            "{\"event_details\":\"#{event_details}\",\"event_start\":\"#{different_event_start}\"}"
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/models/preservation_event_spec.rb
+++ b/spec/models/preservation_event_spec.rb
@@ -74,13 +74,13 @@ RSpec.describe PreservationEvent do
       let(:different_event_start) { DateTime.current.strftime('%FT%T%:z') }
       let(:preservation_event) do
         event = described_class.new(
-          event_type:       event_type,
-          initiating_user:  initiating_user,
-          event_start:      different_event_start,
-          event_end:        event_end,
-          outcome:          outcome,
-          software_version: software_version,
-          event_details:    event_details
+          event_type:,
+          initiating_user:,
+          event_start: different_event_start,
+          event_end:,
+          outcome:,
+          software_version:,
+          event_details:
         )
 
         persister.save(resource: event)


### PR DESCRIPTION
- app/controllers/hyrax/publications_controller.rb: includes module that contains creation methods and inserts those into `create` and `update` controller actions. Also defines Publication event attribute hashes.
- app/models/preservation*: institutes model that pulls its attributes from the metadata yaml of the same name.
- app/models/publication.rb: provides Publication class with instance methods that either set or get the association between object and its preservation events.
- config/metadata/preservation*: lists the attributes with their predicates to be used in each preservation model.
- config/metadata/publication_metadata.yaml: defines an attribute that holds a comma-separated string of PreservationEvent ids.
- lib/preservation_events.rb: creates module that provides a PreservationEvent creation method.