### PR TITLE
Creates a prototype workflow for SelfDeposit users to get work approved.

### DIFF
--- a/app/services/self_deposit/workflow/register_approval_preservation_event.rb
+++ b/app/services/self_deposit/workflow/register_approval_preservation_event.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+require './lib/preservation_events'
+
+module SelfDeposit
+  module Workflow
+    module RegisterApprovalPreservationEvent
+      extend ::PreservationEvents
+
+      ##
+      # This is a function for the emory_mediated_deposit workflow, creating a
+      #   PreservationEvent chronicling the approval of the Publication by an
+      #   appointed approver.
+      #
+      # @param target: Publication instance
+      #
+      # @return Publication Instance
+      def self.call(target:, user:, **)
+        approval_event = {
+          'type' => 'Metadata modification',
+          'start' => DateTime.current,
+          'outcome' => 'Success',
+          'details' => 'Deposit reviewed and approved',
+          'software_version' => 'SelfDeposit v.1',
+          'user' => user.email
+        }
+        model = target.try(:model) || target # get the model if target is a ChangeSet
+
+        create_preservation_event(model, approval_event)
+      end
+    end
+  end
+end

--- a/config/workflows/emory_mediated_deposit_workflow.json
+++ b/config/workflows/emory_mediated_deposit_workflow.json
@@ -1,0 +1,29 @@
+{
+    "workflows": [
+        {
+            "name": "emory_mediated_deposit",
+            "label": "SelfDeposit's mediated deposit workflow",
+            "description": "Emory's workflow for mediated deposit within SelfDeposit in which all deposits made through the UI must be approved by a reviewer. Reviewer will make changes to Publication (if needed) and approve it.",
+            "allows_access_grant": false,
+            "actions": [
+                {
+                    "name": "deposit",
+                    "from_states": [],
+                    "transition_to": "under_review",
+                    "methods": [
+                        "Hyrax::Workflow::GrantReadToDepositor",
+                        "Hyrax::Workflow::RevokeEditFromDepositor",
+                        "Hyrax::Workflow::ActivateObject"
+                    ]
+                }, {
+                    "name": "approve",
+                    "from_states": [{"names": ["under_review"], "roles": ["approving"]}],
+                    "transition_to": "deposited",
+                    "methods": [
+                        "SelfDeposit::Workflow::RegisterApprovalPreservationEvent"
+                    ]
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
- app/services/self_deposit/workflow/register_approval_preservation_event.rb: creates a PreservationEvent chronicling the approval of a Publication instance.
- config/workflows/emory_mediated_deposit_workflow.json: initiates the prototype workflow in the appropriate folder.

NOTE: in order for this to populate as an option in workflows, the following command must be run after deployment:

```
rails hyrax:workflow:load
```