### PR TITLE
Indexes preservation objects into Publication's SolrDocuments.

### DIFF
--- a/app/indexers/publication_indexer.rb
+++ b/app/indexers/publication_indexer.rb
@@ -7,10 +7,23 @@ class PublicationIndexer < Hyrax::Indexers::PcdmObjectIndexer(Publication)
   include Hyrax::Indexer(:publication_metadata)
 
   # Uncomment this block if you want to add custom indexing behavior:
-  #  def to_solr
-  #    super.tap do |index_document|
-  #      index_document[:my_field_tesim]   = resource.my_field.map(&:to_s)
-  #      index_document[:other_field_ssim] = resource.other_field
-  #    end
-  #  end
+  def to_solr
+    super.tap do |index_document|
+      index_document[:failed_preservation_events_ssim] = failed_preservation_events
+      index_document[:preservation_events_tesim] = resource&.preservation_events&.map(&:preservation_event_terms)
+      index_document[:preservation_workflow_terms_tesim] = preservation_workflow_terms
+    end
+  end
+
+  private
+
+  def failed_preservation_events
+    failures = resource.preservation_events.select { |event| event.outcome == "Failure" }
+    return if failures.blank?
+    failures.map(&:failed_event_json)
+  end
+
+  def preservation_workflow_terms
+    resource.preservation_workflows.map(&:preservation_terms)
+  end
 end

--- a/spec/indexers/publication_indexer_spec.rb
+++ b/spec/indexers/publication_indexer_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+# Generated via
+#  `rails generate hyrax:work_resource Monograph`
+require 'rails_helper'
+require 'hyrax/specs/shared_specs/indexers'
+
+RSpec.describe PublicationIndexer do
+  shared_context 'with typical indexer and preservation_event' do
+    before do
+      allow(resource).to receive(:preservation_events).and_return([preservation_event])
+    end
+  end
+  let(:indexer) { indexer_class.new(resource:) }
+  let(:resource) { Publication.new }
+  let(:indexer_class) { described_class }
+  let(:preservation_event) { PreservationEvent.new(attributes) }
+  let(:attributes) do
+    { event_type: 'Reckoning',
+      initiating_user: 'bilbo.baggins@example.com',
+      event_start: '07/04/1776',
+      event_end: '08/29/1997',
+      outcome: 'Nothing',
+      software_version: 'Cyberdine Systems T800',
+      event_details: 'John Connor Lives' }
+  end
+
+  it_behaves_like 'a Hyrax::Resource indexer'
+
+  context 'preservation_events_tesim' do
+    include_context 'with typical indexer and preservation_event'
+
+    it 'contains a json object of the PreservationEvent' do
+      expect(indexer.to_solr['preservation_events_tesim']).to eq(
+        ["{\"event_details\":\"John Connor Lives\",\"event_end\":\"08/29/1997\",\"event_start\":\"07/04/1776\",\"event_type\":\"Reckoning\"," \
+         "\"initiating_user\":\"bilbo.baggins@example.com\",\"outcome\":\"Nothing\",\"software_version\":\"Cyberdine Systems T800\"}"]
+      )
+    end
+  end
+
+  context 'failed_preservation_events_ssim' do
+    let(:preservation_event) { PreservationEvent.new(attributes.merge(outcome: 'Failure')) }
+    include_context 'with typical indexer and preservation_event'
+
+    it 'contains a failure-formatted json object of the PreservationEvent' do
+      expect(indexer.to_solr['failed_preservation_events_ssim']).to eq(
+        ["{\"event_details\":\"John Connor Lives\",\"event_start\":\"07/04/1776\"}"]
+      )
+    end
+  end
+
+  context 'preservation_workflow_terms_tesim' do
+    let(:preservation_workflow) { PreservationWorkflow.new(attributes) }
+    let(:attributes) do
+      { workflow_type: 'example',
+        workflow_notes: 'notes',
+        workflow_rights_basis: 'rights basis',
+        workflow_rights_basis_note: 'note',
+        workflow_rights_basis_date: '02/02/2012',
+        workflow_rights_basis_reviewer: 'reviewer',
+        workflow_rights_basis_uri: 'uri' }
+    end
+
+    before do
+      allow(resource).to receive(:preservation_workflows).and_return([preservation_workflow])
+    end
+
+    it 'contains a json object of the PreservationWorkflow' do
+      expect(indexer.to_solr['preservation_workflow_terms_tesim']).to eq(
+        ["{\"workflow_type\":\"example\",\"workflow_notes\":\"notes\",\"workflow_rights_basis\":\"rights basis\",\"workflow_rights_basis_note\":\"note\"," \
+         "\"workflow_rights_basis_date\":\"02/02/2012\",\"workflow_rights_basis_reviewer\":\"reviewer\",\"workflow_rights_basis_uri\":\"uri\"}"]
+      )
+    end
+  end
+end


### PR DESCRIPTION
- app/indexers/publication_indexer.rb: creates 3 new Solr fields to accommodate Preservatio objects.
-  spec/indexers/publication_indexer_spec.rb: tests the population of the fields created by the indexer.