### PR TITLE
Adds PreservationEvents for FileSets to indexer.

### DIFF
--- a/app/indexers/self_deposit/indexers/file_set_indexer.rb
+++ b/app/indexers/self_deposit/indexers/file_set_indexer.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+module SelfDeposit
+  module Indexers
+    ##
+    # Hyrax v5.0.0 Override - Adds our own customized Solr fields to accommodate PreservationEvent values.
+    # Indexes ::FileSet objects
+    class FileSetIndexer < Hyrax::Indexers::FileSetIndexer
+      def to_solr
+        super.tap do |solr_doc|
+          solr_doc['preservation_events_tesim'] = resource&.preservation_events&.map(&:preservation_event_terms)
+        end
+      end
+    end
+  end
+end

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -260,6 +260,9 @@ Hyrax.config do |config|
   # config.admin_set_model = 'AdminSet'
   config.admin_set_model = 'Hyrax::AdministrativeSet'
 
+  # Identify the indexer that will be used for File Sets
+  config.file_set_indexer = SelfDeposit::Indexers::FileSetIndexer
+
   # When your application is ready to use the valkyrie index instead of the one
   # maintained by active fedora, you will need to set this to true. You will
   # also need to update your Blacklight configuration.

--- a/spec/indexers/publication_indexer_spec.rb
+++ b/spec/indexers/publication_indexer_spec.rb
@@ -1,12 +1,9 @@
 # frozen_string_literal: true
-
-# Generated via
-#  `rails generate hyrax:work_resource Monograph`
 require 'rails_helper'
 require 'hyrax/specs/shared_specs/indexers'
 
 RSpec.describe PublicationIndexer do
-  shared_context 'with typical indexer and preservation_event' do
+  shared_context 'with typical preservation_event' do
     before do
       allow(resource).to receive(:preservation_events).and_return([preservation_event])
     end
@@ -28,7 +25,7 @@ RSpec.describe PublicationIndexer do
   it_behaves_like 'a Hyrax::Resource indexer'
 
   context 'preservation_events_tesim' do
-    include_context 'with typical indexer and preservation_event'
+    include_context 'with typical preservation_event'
 
     it 'contains a json object of the PreservationEvent' do
       expect(indexer.to_solr['preservation_events_tesim']).to eq(
@@ -40,7 +37,7 @@ RSpec.describe PublicationIndexer do
 
   context 'failed_preservation_events_ssim' do
     let(:preservation_event) { PreservationEvent.new(attributes.merge(outcome: 'Failure')) }
-    include_context 'with typical indexer and preservation_event'
+    include_context 'with typical preservation_event'
 
     it 'contains a failure-formatted json object of the PreservationEvent' do
       expect(indexer.to_solr['failed_preservation_events_ssim']).to eq(

--- a/spec/indexers/self_deposit/indexers/file_set_indexer_spec.rb
+++ b/spec/indexers/self_deposit/indexers/file_set_indexer_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+require 'rails_helper'
+require 'hyrax/specs/shared_specs/indexers'
+
+RSpec.describe SelfDeposit::Indexers::FileSetIndexer do
+  shared_context 'with typical preservation_event' do
+    before do
+      allow(resource).to receive(:preservation_events).and_return([preservation_event])
+    end
+  end
+  let(:indexer) { indexer_class.new(resource:) }
+  let(:resource) { ::FileSet.new }
+  let(:indexer_class) { described_class }
+  let(:preservation_event) { PreservationEvent.new(attributes) }
+  let(:attributes) do
+    { event_type: 'Reckoning',
+      initiating_user: 'bilbo.baggins@example.com',
+      event_start: '07/04/1776',
+      event_end: '08/29/1997',
+      outcome: 'Nothing',
+      software_version: 'Cyberdine Systems T800',
+      event_details: 'John Connor Lives' }
+  end
+
+  it_behaves_like 'a Hyrax::Resource indexer'
+
+  context 'preservation_events_tesim' do
+    include_context 'with typical preservation_event'
+
+    it 'contains a json object of the PreservationEvent' do
+      expect(indexer.to_solr['preservation_events_tesim']).to eq(
+        ["{\"event_details\":\"John Connor Lives\",\"event_end\":\"08/29/1997\",\"event_start\":\"07/04/1776\",\"event_type\":\"Reckoning\"," \
+         "\"initiating_user\":\"bilbo.baggins@example.com\",\"outcome\":\"Nothing\",\"software_version\":\"Cyberdine Systems T800\"}"]
+      )
+    end
+  end
+end


### PR DESCRIPTION
- app/indexers/self_deposit/indexers/file_set_indexer.rb: creates Emory SelfDeposit's own Indexer that inherits from Hyrax' own class. Then creates a new Solr field to store the `PreservationEvent` objects in.
- config/initializers/hyrax.rb: tells the Hyrax engine to use ours instead.
- spec/indexers/publication_indexer_spec.rb: corrects descriptive text.
- spec/indexers/self_deposit/indexers/file_set_indexer_spec.rb: tests the `PreservationEvent` indexing.