### PR TITLE
Ensures persistence of new attribute file_set_use.

### DIFF
--- a/app/forms/concerns/emory_file_set_metadata_extension.rb
+++ b/app/forms/concerns/emory_file_set_metadata_extension.rb
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-module EmoryFileSetMetadataExtension
-  extend ActiveSupport::Concern
-  included do
-    include Hyrax::FormFields(:emory_file_set_metadata) if respond_to?(:include_hyrax_form_fields)
-    self.terms += [:pcdm_use] if respond_to?(:terms) && !terms.include?(:pcdm_use)
-  end
-end

--- a/app/forms/self_deposit/forms/file_set_form.rb
+++ b/app/forms/self_deposit/forms/file_set_form.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module SelfDeposit
+  module Forms
+    ##
+    # SelfDeposits form for +Hyrax::FileSet+s with inheritance from Hyrax::Forms::FileSetForm.
+    class FileSetForm < Hyrax::Forms::FileSetForm
+      include Hyrax::FormFields(:emory_file_set_metadata)
+    end
+  end
+end

--- a/app/indexers/self_deposit/indexers/file_set_indexer.rb
+++ b/app/indexers/self_deposit/indexers/file_set_indexer.rb
@@ -5,6 +5,8 @@ module SelfDeposit
     # Hyrax v5.0.0 Override - Adds our own customized Solr fields to accommodate PreservationEvent values.
     # Indexes ::FileSet objects
     class FileSetIndexer < Hyrax::Indexers::FileSetIndexer
+      include Hyrax::Indexer(:emory_file_set_metadata)
+
       def to_solr
         super.tap do |solr_doc|
           solr_doc['preservation_events_tesim'] = resource&.preservation_events&.map(&:preservation_event_terms)

--- a/app/views/hyrax/file_sets/_form.html.erb
+++ b/app/views/hyrax/file_sets/_form.html.erb
@@ -5,10 +5,12 @@
     </span>
     <%= text_field_tag 'file_set[title][]', curation_concern.title.first, class: 'form-control', required: true %>
      <span class="control-label">
-      <%= label_tag 'file_set[pcdm_use]', t('.pcdm_use'),  class: "string optional" %>
+      <%= label_tag 'file_set[file_set_use]', 'Fileset Use',  class: "string optional" %>
     </span>
     <div>
-      <%= select_tag 'file_set[pcdm_use]', options_for_select(["#{FileSet::PRIMARY}", "#{FileSet::SUPPLEMENTAL}", "#{FileSet::PRESERVATION}"], curation_concern.pcdm_use), class: 'form-control' %>
+      <%= select_tag 'file_set[file_set_use]',
+          options_for_select([FileSet::PRIMARY, FileSet::SUPPLEMENTAL, FileSet::PRESERVATION], curation_concern&.file_set_use&.presence || FileSet::PRIMARY),
+          class: 'form-control' %>
     </div>
   </fieldset>
 

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -263,6 +263,9 @@ Hyrax.config do |config|
   # Identify the indexer that will be used for File Sets
   config.file_set_indexer = SelfDeposit::Indexers::FileSetIndexer
 
+  # Identify the form that will be used for File Sets
+  config.file_set_form = SelfDeposit::Forms::FileSetForm
+
   # When your application is ready to use the valkyrie index instead of the one
   # maintained by active fedora, you will need to set this to true. You will
   # also need to update your Blacklight configuration.

--- a/config/initializers/hyrax_edit_permissions_service_override.rb
+++ b/config/initializers/hyrax_edit_permissions_service_override.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+# [Hyrax-overwrite-v5.0.1] - Hyrax Bug!
+#   When testing what type of form the application is using in the case of FileSets, the Hyrax::EditPermissionsService
+#   relies on the out-of-box form class but ignores the fact that those using the Hyrax Rails Engine are given the choice
+#   to replace that form with their own in the configuration. We're changing the explicit class to the configuration variable,
+#   which defaults to Hyrax::Forms::FileSetForm.
+#
+# This change will be submitted to Hyrax as a PR.
+
+Rails.application.config.to_prepare do
+  Hyrax::EditPermissionsService.class_eval do
+    ##
+    # @api public
+    # @since v3.0.0
+    #
+    # @param form [SimpleForm::FormBuilder]
+    # @param current_ability [Ability]
+    # @return [Hyrax::EditPermissionService]
+    #
+    # @note
+    #   +form object.class = SimpleForm::FormBuilder+
+    #    For works (i.e. GenericWork):
+    #    * form_object.object = Hyrax::GenericWorkForm
+    #    * form_object.object.model = GenericWork
+    #    * use the work itself
+    #    For file_sets:
+    #    * form_object.object.class = FileSet
+    #    * use work the file_set is in
+    #    For file set forms:
+    #    * form_object.object.class = Hyrax::Forms::FileSetForm (or what is set in Hyrax.config.file_set_form) OR Hyrax::Forms::FileSetEditForm
+    #    * form_object.object.model = FileSet
+    #    * use work the file_set is in
+    #    No other object types are supported by this view.
+    def self.build_service_object_from(form:, ability:) # rubocop:disable Metrics/AbcSize
+      if form.object.respond_to?(:model) && form.object.model.work?
+        # The provided form object is a work form.
+        new(object: form.object, ability:)
+      elsif form.object.respond_to?(:model) && form.object.model.file_set?
+        # The provided form object is a FileSet form. For Valkyrie forms
+        # (+Hyrax::Forms::FileSetForm+), +:in_works_ids+ is prepopulated onto
+        # the form object itself. For +Hyrax::Forms::FileSetEditForm+, the
+        # +:in_works+ method is present on the wrapped +:model+.
+        if form.object.is_a?(Hyrax.config.file_set_form)
+          object_id = form.object.in_works_ids.first
+          new(object: Hyrax.query_service.find_by(id: object_id), ability:)
+        else
+          new(object: form.object.model.in_works.first, ability:)
+        end
+      elsif form.object.file_set?
+        # The provided form object is a FileSet.
+        new(object: form.object.in_works.first, ability:)
+      end
+    end # rubocop:enable Metrics/AbcSize
+  end
+end

--- a/config/initializers/hyrax_overrides.rb
+++ b/config/initializers/hyrax_overrides.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-Rails.application.config.to_prepare do
-  Hyrax::Forms::FileSetForm.include EmoryFileSetMetadataExtension
-  Hyrax::Forms::FileSetEditForm.include EmoryFileSetMetadataExtension
-end

--- a/config/initializers/hyrax_work_uploads_handler_override.rb
+++ b/config/initializers/hyrax_work_uploads_handler_override.rb
@@ -42,5 +42,21 @@ Rails.application.config.to_prepare do
 
       create_preservation_event(file_set, event)
     end
+
+    private
+
+    ##
+    # @api private
+    #
+    # @return [Hash{Symbol => Object}]
+    def file_set_args(file)
+      { depositor: file.user.user_key,
+        creator: file.user.user_key,
+        date_uploaded: file.created_at,
+        date_modified: Hyrax::TimeService.time_in_utc,
+        label: file.uploader.filename,
+        title: file.uploader.filename,
+        file_set_use: FileSet::PRIMARY }
+    end
   end
 end

--- a/config/metadata/emory_file_set_metadata.yaml
+++ b/config/metadata/emory_file_set_metadata.yaml
@@ -1,10 +1,13 @@
 attributes:
+  file_set_use:
+    type: string
+    multiple: false
+    form:
+      required: false
+      primary: false
+    predicate: http://metadata.emory.edu/vocab/cor-terms#fileSetUse
+    index_keys:
+      - "file_set_use_ssi"
   preservation_event_ids:
     type: string
     predicate: http://metadata.emory.edu/vocab/cor-terms#preservationEventIDs
-  pcdm_use:
-    type: string
-    multiple: false
-    predicate: http://pcdm.org/use
-    index_keys:
-      - "pcdm_use_tesim"

--- a/spec/forms/self_deposit/forms/file_set_form_spec.rb
+++ b/spec/forms/self_deposit/forms/file_set_form_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Generated via
+#  `rails generate hyrax:work_resource CollectionResource`
+require 'rails_helper'
+require 'valkyrie/specs/shared_specs'
+
+RSpec.describe SelfDeposit::Forms::FileSetForm do
+  let(:change_set) { described_class.new(resource) }
+  let(:resource)   { ::FileSet.new }
+
+  it_behaves_like 'a Valkyrie::ChangeSet'
+
+  it('contains file_set_use as an expected field') { expect(change_set.fields.keys).to include('file_set_use') }
+end

--- a/spec/indexers/self_deposit/indexers/file_set_indexer_spec.rb
+++ b/spec/indexers/self_deposit/indexers/file_set_indexer_spec.rb
@@ -34,4 +34,10 @@ RSpec.describe SelfDeposit::Indexers::FileSetIndexer do
       )
     end
   end
+
+  context 'file_set_use_ssi' do
+    let(:resource) { ::FileSet.new(file_set_use: ::FileSet::PRIMARY) }
+
+    it('contains the expected text') { expect(indexer.to_solr['file_set_use_ssi']).to eq('Primary Content') }
+  end
 end


### PR DESCRIPTION
- app/forms/concerns/emory_file_set_metadata_extension.rb and config/initializers/hyrax_overrides.rb: removes overrides to  transition to a custom version of `Hyrax::Forms::FileSetForm`.
- app/forms/self_deposit/forms/file_set_form.rb: initiates a custom form class to allow us to easily transform FileSet form fields.
- app/indexers/self_deposit/indexers/file_set_indexer.rb: passes Emory's desired FileSet Solr fields to the indexer.
- app/views/hyrax/file_sets/_form.html.erb: switches the field name to the new attribute since `pcdm_use` is heavily used in the base Hyrax engine.
- config/initializers/hyrax.rb: stubs our new custom FileSet form class into Hyrax' configuration.
- config/initializers/hyrax_edit_permissions_service_override.rb: overrides `Hyrax::EditPermissionsService` because it doesn't allow custom FileSet form classes to be used for testing purposes instead of the hard coded default class.
- config/initializers/hyrax_work_uploads_handler_override.rb: provides a default value for `file_set_use` when FileSets are created.
- config/metadata/emory_file_set_metadata.yaml: changes file set use field's name and provides form attributes to allow Form class logic to recognize the field as necessary and permitted when attempting update through UI.
- spec/*: tests that new field can be persisted in Solr and is available to the form that passes the values to new/update controller actions.