### PR TITLE
Utilizes direct binary contents instead of attempting to pull file.

### DIFF
--- a/config/initializers/valkyrie_characterization_service_override.rb
+++ b/config/initializers/valkyrie_characterization_service_override.rb
@@ -51,8 +51,8 @@ Rails.application.config.to_prepare do
       value = terms[:original_checksum]
       return if value.empty?
       value.first.prepend("urn:md5:").to_s
-      sha256 = Digest::SHA256.file(metadata.file.io.path).hexdigest.prepend("urn:sha256:")
-      sha1 = Digest::SHA1.file(metadata.file.io.path).hexdigest.prepend("urn:sha1:")
+      sha256 = digest_sha256
+      sha1 = digest_sha1
       value.push(sha1, sha256)
     end
 
@@ -76,6 +76,28 @@ Rails.application.config.to_prepare do
     def pres_event_details(metadata_populated, metadata, file_set)
       return "#{file_set.characterization_proxy}: #{metadata.original_filename} - Technical metadata extracted from file, format identified, and file validated" if metadata_populated
       "The Characterization Service failed."
+    end
+
+    def digest_sha256
+      sha = Digest::SHA256.new
+      file = metadata.file
+
+      file.rewind
+      while (chunk = file.read(256))
+        sha << chunk
+      end
+      sha.hexdigest.prepend("urn:sha256:")
+    end
+
+    def digest_sha1
+      sha = Digest::SHA1.new
+      file = metadata.file
+
+      file.rewind
+      while (chunk = file.read(1))
+        sha << chunk
+      end
+      sha.hexdigest.prepend("urn:sha1:")
     end
   end
 end

--- a/spec/services/hyrax/characterization/valkyrie_characterization_service_spec.rb
+++ b/spec/services/hyrax/characterization/valkyrie_characterization_service_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 
 RSpec.describe Hyrax::Characterization::ValkyrieCharacterizationService do
   describe "#transform_original_checksum" do
-    let(:file) { "spec/fixtures/world.png" }
+    let(:file) { File.open("spec/fixtures/world.png") }
     let(:file_metadata) { instance_double(Hyrax::FileMetadata) }
 
     it 'produces three SHA digests' do
@@ -20,7 +20,7 @@ RSpec.describe Hyrax::Characterization::ValkyrieCharacterizationService do
                 width: ["145"],
                 height: ["150"],
                 color_space: ["BlackIsZero"] }.to_h
-      allow(file_metadata).to receive_message_chain(:file, :io, :path).and_return(file)
+      allow(file_metadata).to receive(:file).and_return(file)
       described_class.new(metadata: file_metadata, file:, **Hyrax.config.characterization_options).transform_original_checksum(terms)
 
       expect(terms[:original_checksum].size).to eq(3)


### PR DESCRIPTION
- config/initializers/valkyrie_characterization_service_override.rb: stops the pulling of the file by filepath and instead relies directly on the file contents.
- spec/services/hyrax/characterization/valkyrie_characterization_service_spec.rb: passes the file directly instead of the filepath.