### PR TITLE
adds and removes form fields

### DIFF
--- a/app/forms/publication_form.rb
+++ b/app/forms/publication_form.rb
@@ -26,7 +26,7 @@ class PublicationForm < Hyrax::Forms::PcdmObjectForm(Publication)
   def publication_information
     [:title, :creator, :language, :date_issued, :publisher, :publisher_version,
      :rights_statement, :license, :final_published_versions, :parent_title, :conference_name,
-     :issn, :series_title, :edition, :volume, :issue, :page_range_start, :page_range_end,
+     :issn, :isbn, :series_title, :edition, :volume, :issue, :page_range_start, :page_range_end,
      :place_of_production, :sponsor, :grant_agencies, :grant_information, :related_datasets]
   end
 
@@ -35,9 +35,9 @@ class PublicationForm < Hyrax::Forms::PcdmObjectForm(Publication)
   end
 
   def administrative_terms
-    [:emory_ark, :rights_statement, :internal_rights_note, :staff_notes, :access_right,
+    [:emory_ark, :internal_rights_note, :staff_notes, :access_right,
      :system_of_record_ID, :emory_content_type, :holding_repository, :institution,
-     :data_classification, :date_created, :deduplication_key]
+     :data_classification, :deduplication_key]
   end
 
   def genres_block

--- a/config/metadata/emory_basic_metadata.yaml
+++ b/config/metadata/emory_basic_metadata.yaml
@@ -69,8 +69,6 @@ attributes:
   date_created:
     type: date_time
     multiple: true
-    form:
-      primary: false
     index_keys:
       - "date_created_tesim"
     predicate: http://purl.org/dc/terms/created

--- a/config/metadata/publication_metadata.yaml
+++ b/config/metadata/publication_metadata.yaml
@@ -31,9 +31,6 @@ attributes:
   conference_dates:
     type: string
     multiple: false
-    form:
-      primary: false
-      multiple: false
     index_keys:
       - 'conference_dates_si'
       - 'conference_dates_tesi'
@@ -176,6 +173,15 @@ attributes:
     index_keys:
       - 'issn_tesi'
     predicate: http://id.loc.gov/vocabulary/identifiers/issn
+  isbn:
+    type: string
+    multiple: false
+    form:
+      primary: true
+      multiple: false
+    index_keys:
+      - 'isbn_tesi'
+    predicate: http://id.loc.gov/vocabulary/identifiers/isbn
   issue:
     type: string
     multiple: false


### PR DESCRIPTION
To remove:

 Description (we don't need both a Description and an Abstract, because for Publications we expect Abstracts)
 Conference Dates (conference_dates)
 Date Created (date_created)
 rights_statement - this appears in 2 form sections. It should only appear in the Publication section of the form.

To add:

 ISBN (isbn from Curate fields)
