### PR TITLE
Restrict visibility options in form to admin-only.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,6 +63,7 @@ group :development, :test do
   gem 'pry-doc'
   gem 'pry-rails'
   gem 'pry-rescue'
+  gem 'rspec-activemodel-mocks'
   gem 'rspec-rails'
   gem 'rubocop', require: false
   gem 'rubocop-capybara', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -853,6 +853,10 @@ GEM
     rsolr (2.5.0)
       builder (>= 2.1.2)
       faraday (>= 0.9, < 3, != 2.0.0)
+    rspec-activemodel-mocks (1.2.0)
+      activemodel (>= 3.0)
+      activesupport (>= 3.0)
+      rspec-mocks (>= 2.99, < 4.0)
     rspec-core (3.13.0)
       rspec-support (~> 3.13.0)
     rspec-expectations (3.13.0)
@@ -1108,6 +1112,7 @@ DEPENDENCIES
   rails (~> 6.1)
   riiif (~> 2.1)
   rsolr (>= 1.0, < 3)
+  rspec-activemodel-mocks
   rspec-rails
   rspec_junit_formatter
   rubocop

--- a/app/views/hyrax/base/_form_visibility_component.html.erb
+++ b/app/views/hyrax/base/_form_visibility_component.html.erb
@@ -1,0 +1,78 @@
+<%# Hyrax v5.0.1 Override: hides Institution, Lease, and Private is user is non-admin %>
+
+<% if embargo_enforced?(f.object) %>
+  <%= render 'form_permission_under_embargo', f: f %>
+<% elsif lease_enforced?(f.object) %>
+  <%= render 'form_permission_under_lease', f: f %>
+<% else %>
+    <fieldset>
+      <% if local_assigns[:save_work] %>
+        <legend class="legend-save-work"><%= t('.visibility') %></legend>
+      <% else %>
+        <legend><%= t('.visibility') %><%= raw(t('.subtitle_html')) %></legend>
+      <% end %>
+      <ul class="visibility">
+        <li class="form-check">
+          <label class="form-check-label">
+            <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC, class: 'form-check-input', data: { 'target': '#collapsePublic' } %>
+            <%= visibility_badge(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC) %>
+            <br />
+            <%= t('hyrax.visibility.open.note_html', type: f.object.human_readable_type) %>
+            <div class="collapse" id="collapsePublic">
+              <%= t('hyrax.visibility.open.warning_html', label: visibility_badge(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC)) %>
+            </div>
+          </label>
+        </li>
+        <li class="form-check">
+          <label class="form-check-label">
+            <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO, 'aria-label': 'Embargo', class: 'form-check-input', data: { 'target': '#collapseEmbargo' } %>
+            <%= visibility_badge(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO) %>
+            <br />
+            <%= t('hyrax.visibility.embargo.note_html') %>
+            <div class="collapse" id="collapseEmbargo">
+              <div class="form-inline">
+                <%= f.input :visibility_during_embargo, wrapper: :inline, collection: visibility_options(:restrict), include_blank: false %>
+                <%= t('hyrax.works.form.visibility_until') %>
+                <%= f.date_field :embargo_release_date, wrapper: :inline, 'aria-label': 'Embargo Release Date', value: f.object.embargo_release_date&.to_date || Date.tomorrow, class: 'datepicker form-control' %>
+                <%= f.input :visibility_after_embargo, wrapper: :inline, collection: visibility_options(:loosen), include_blank: false %>
+              </div>
+            </div>
+          </label>
+        </li>
+        <% if current_user.admin? %>
+          <li class="form-check">
+            <label class="form-check-label">
+              <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED, class: 'form-check-input' %>
+              <%= visibility_badge(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED) %>
+              <br />
+              <%= t('hyrax.visibility.authenticated.note_html', institution: institution_name) %>
+            </label>
+          </li>
+          <li class="form-check">
+            <label class="form-check-label">
+              <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_LEASE, 'aria-label': 'Lease', class: 'form-check-input', data: { 'target': '#collapseLease' } %>
+              <%= visibility_badge(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_LEASE) %>
+              <br />
+              <%= t('hyrax.visibility.lease.note_html') %>
+              <div class="collapse" id="collapseLease">
+                <div class="form-inline">
+                  <%= f.input :visibility_during_lease, wrapper: :inline, collection: visibility_options(:loosen), include_blank: false %>
+                  <%= t('hyrax.works.form.visibility_until') %>
+                  <%= f.date_field :lease_expiration_date, wrapper: :inline, 'aria-label': 'Lease Expiration Date', value: f.object.lease_expiration_date&.to_date || Date.tomorrow, class: 'datepicker form-control' %>
+                  <%= f.input :visibility_after_lease, wrapper: :inline, collection: visibility_options(:restrict), include_blank: false %>
+                </div>
+              </div>
+            </label>
+          </li>
+          <li class="form-check">
+            <label class="form-check-label">
+              <%= f.radio_button :visibility, Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE, class: 'form-check-input' %>
+              <%= visibility_badge(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE) %>
+              <br />
+              <%= t('hyrax.visibility.restricted.note_html') %>
+            </label>
+          </li>
+        <% end %>
+      </ul>
+    </fieldset>
+<% end %>

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@ require 'factory_bot'
 require 'hyrax/specs/shared_specs/factories/strategies/json_strategy'
 require 'hyrax/specs/shared_specs/factories/strategies/valkyrie_resource'
 require 'coveralls'
+require 'rspec/active_model/mocks'
 
 Coveralls.wear!('rails')
 

--- a/spec/views/hyrax/base/_form_visibility_component.html.erb_spec.rb
+++ b/spec/views/hyrax/base/_form_visibility_component.html.erb_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe 'hyrax/base/_form_visibility_component.html.erb', type: :view do
+  let(:user) { stub_model(User) }
+  let(:publication) { Publication.new }
+  let(:form) { Hyrax::Forms::ResourceForm.for(resource: publication) }
+  let(:form_template) do
+    %(
+      <%= simple_form_for [main_app, @form] do |f| %>
+        <%= render "hyrax/base/form_visibility_component", f: f %>
+      <% end %>
+    )
+  end
+
+  let(:rendered_save) do
+    # explicitly save rendered, as it seems to become empty at some point during processing
+    assign(:form, form)
+    render inline: form_template
+  end
+
+  let(:page) do
+    Capybara::Node::Simple.new(rendered_save)
+  end
+
+  before do
+    allow(view).to receive(:current_user).and_return(user)
+    allow(view).to receive(:action_name).and_return('new')
+  end
+
+  shared_examples 'renders the expected lis' do |num_of_lis, expected_badges|
+    it "renders only #{num_of_lis} options for the visibility assignment" do
+      pulled_lis = page.find_all('li', class: 'form-check')
+
+      expect(pulled_lis.size).to eq(num_of_lis)
+      expect(pulled_lis.map { |li| li.find_css('label span.badge').text }).to match_array(expected_badges)
+    end
+  end
+
+  context 'typical user' do
+    include_examples 'renders the expected lis', 2, ['PublicPublic', 'Embargo']
+  end
+
+  context 'admin user' do
+    before { allow(user).to receive(:admin?).and_return(true) }
+
+    include_examples 'renders the expected lis', 5, ["Embargo", "Institution", "Lease", "Private", "PublicPublic"]
+  end
+end


### PR DESCRIPTION
- Gemfile* and spec/spec_helper.rb: adds gem that allows method `#stub_model` that is used throughout Hyrax' spec.
- app/views/hyrax/base/_form_visibility_component.html.erb: overrides the Hyrax template to restrict certain options to admin-only.
- spec/views/hyrax/base/_form_visibility_component.html.erb_spec.rb: tests the restriction of the visibility options.