### PR TITLE
Creates a custom query to pull a work's parent work.

### DIFF
--- a/app/services/hyrax/listeners/member_cleanup_listener.rb
+++ b/app/services/hyrax/listeners/member_cleanup_listener.rb
@@ -21,7 +21,7 @@ module Hyrax
           parent.member_ids -= [object.id]
           Hyrax.persister.save(resource: parent)
           Hyrax.index_adapter.save(resource: parent)
-          Hyrax.publisher.publish('object.membership.updated', object: parent, user: user)
+          Hyrax.publisher.publish('object.membership.updated', object: parent, user:)
         end
       end
 

--- a/app/services/hyrax/listeners/member_cleanup_listener.rb
+++ b/app/services/hyrax/listeners/member_cleanup_listener.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+# Hyrax v5.0.1 override: L#20 uses custom query that avoids looking up work in Fedora.
+
+module Hyrax
+  module Listeners
+    ##
+    # Listens for resource deleted events and cleans up associated members
+    class MemberCleanupListener
+      # Called when 'object.deleted' event is published
+      # @param [Dry::Events::Event] event
+      # @return [void]
+      def on_object_deleted(event)
+        event = event.to_h
+        return unless event[:object]
+
+        object = event[:object]
+        user = event[:user]
+        return unless object.is_a?(Hyrax::Work)
+
+        Hyrax.custom_queries.find_parent_works(resource: object).each do |parent|
+          parent.member_ids -= [object.id]
+          Hyrax.persister.save(resource: parent)
+          Hyrax.index_adapter.save(resource: parent)
+          Hyrax.publisher.publish('object.membership.updated', object: parent, user: user)
+        end
+      end
+
+      # Called when 'collection.deleted' event is published
+      # @param [Dry::Events::Event] event
+      # @return [void]
+      def on_collection_deleted(event); end
+    end
+  end
+end

--- a/app/services/self_deposit/custom_queries/find_parent_works.rb
+++ b/app/services/self_deposit/custom_queries/find_parent_works.rb
@@ -25,9 +25,6 @@ module SelfDeposit
       # @return Work Objects
       def find_parent_works(resource:)
         @resource = resource
-        # query_service
-        #   .find_all_of_model(model: resource.internal_resource.constantize)
-        #   .find_all { |obj| obj.member_ids.map(&:to_s).include? resource.id.to_s }
         enum_for(:each)
       end
 

--- a/app/services/self_deposit/custom_queries/find_parent_works.rb
+++ b/app/services/self_deposit/custom_queries/find_parent_works.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+module SelfDeposit
+  module CustomQueries
+    # @example
+    #   resource = Valkyrie Object
+    #
+    #   Hyrax.custom_queries.find_parent_works(resource:)
+    #
+    # @see https://github.com/samvera/valkyrie/wiki/Queries#custom-queries
+    class FindParentWorks
+      def self.queries
+        [:find_parent_works]
+      end
+
+      def initialize(query_service:)
+        @query_service = query_service
+      end
+
+      attr_reader :query_service
+      delegate :resource_factory, to: :query_service
+
+      ##
+      # @param Valkyrie object for a Hyrax::Work
+      #
+      # @return Work Objects
+      def find_parent_works(resource:)
+        query_service
+          .find_all_of_model(model: resource.internal_resource.constantize)
+          .find_all { |obj| obj.member_ids.map(&:to_s).include? resource.id.to_s }
+      end
+    end
+  end
+end

--- a/app/services/self_deposit/custom_queries/find_parent_works.rb
+++ b/app/services/self_deposit/custom_queries/find_parent_works.rb
@@ -14,19 +14,41 @@ module SelfDeposit
 
       def initialize(query_service:)
         @query_service = query_service
+        @connection = Hyrax.index_adapter.connection
       end
 
       attr_reader :query_service
-      delegate :resource_factory, to: :query_service
 
       ##
       # @param Valkyrie object for a Hyrax::Work
       #
       # @return Work Objects
       def find_parent_works(resource:)
-        query_service
-          .find_all_of_model(model: resource.internal_resource.constantize)
-          .find_all { |obj| obj.member_ids.map(&:to_s).include? resource.id.to_s }
+        @resource = resource
+        # query_service
+        #   .find_all_of_model(model: resource.internal_resource.constantize)
+        #   .find_all { |obj| obj.member_ids.map(&:to_s).include? resource.id.to_s }
+        enum_for(:each)
+      end
+
+      # Queries for all Documents in the Solr index
+      # For each Document, it yields the Valkyrie Resource which was converted from it
+      # @yield [Valkyrie::Resource]
+      def each
+        docs = Valkyrie::Persistence::Solr::Queries::DefaultPaginator.new
+        while docs.has_next?
+          docs = @connection.paginate(docs.next_page, docs.per_page, "select", params: { q: query })["response"]["docs"]
+          docs.each do |doc|
+            yield Hyrax.query_service.find_by(id: doc['id'])
+          end
+        end
+      end
+
+      # Query Solr for for all documents with the ID in the requested field
+      # @note the field used here is a _ssim dynamic field and the value is prefixed by "id-"
+      # @return [Hash]
+      def query
+        "member_ids_ssim:#{@resource.id}"
       end
     end
   end

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -340,7 +340,8 @@ custom_queries = [Hyrax::CustomQueries::Navigators::CollectionMembers,
                   Hyrax::CustomQueries::FindModelsByAccess,
                   Hyrax::CustomQueries::FindCountBy,
                   Hyrax::CustomQueries::FindByDateRange,
-                  SelfDeposit::CustomQueries::FindPublicationByDeduplicationKey]
+                  SelfDeposit::CustomQueries::FindPublicationByDeduplicationKey,
+                  SelfDeposit::CustomQueries::FindParentWorks]
 custom_queries.each do |handler|
   Hyrax.query_service.custom_queries.register_query_handler(handler)
 end


### PR DESCRIPTION
- app/services/hyrax/listeners/member_cleanup_listener.rb: pulls in listener to override the query it uses to pull a work's parent work.
- app/services/self_deposit/custom_queries/find_parent_works.rb: creates a custom query to find a work's parent works.
- config/initializers/hyrax.rb: adds new custom query to the Hyrax initializer.