### PR TITLE
Reworks and refactors our custom queries.

### DIFF
--- a/app/services/self_deposit/custom_queries/find_parent_works.rb
+++ b/app/services/self_deposit/custom_queries/find_parent_works.rb
@@ -2,7 +2,7 @@
 module SelfDeposit
   module CustomQueries
     # @example
-    #   resource = Valkyrie Object
+    #   resource = Valkyrie Work Object
     #
     #   Hyrax.custom_queries.find_parent_works(resource:)
     #
@@ -20,29 +20,28 @@ module SelfDeposit
       attr_reader :query_service
 
       ##
-      # @param Valkyrie object for a Hyrax::Work
+      # @param Valkyrie object for a Hyrax Work type
       #
-      # @return Work Objects
+      # @return enumerator of Hyrax Work objects
       def find_parent_works(resource:)
         @resource = resource
         enum_for(:each)
       end
 
-      # Queries for all Documents in the Solr index
-      # For each Document, it yields the Valkyrie Resource which was converted from it
+      # Queries the Solr index for parent works of the provided resource
+      # For each Document, it yields the pulled Hyrax Work object
       # @yield [Valkyrie::Resource]
       def each
         docs = Valkyrie::Persistence::Solr::Queries::DefaultPaginator.new
         while docs.has_next?
           docs = @connection.paginate(docs.next_page, docs.per_page, "select", params: { q: query })["response"]["docs"]
           docs.each do |doc|
-            yield Hyrax.query_service.find_by(id: doc['id'])
+            yield query_service.find_by(id: doc['id'])
           end
         end
       end
 
-      # Query Solr for for all documents with the ID in the requested field
-      # @note the field used here is a _ssim dynamic field and the value is prefixed by "id-"
+      # Query Solr for for all documents with the ID in the member_ids_ssim field
       # @return [Hash]
       def query
         "member_ids_ssim:#{@resource.id}"

--- a/app/services/self_deposit/custom_queries/find_publication_by_deduplication_key.rb
+++ b/app/services/self_deposit/custom_queries/find_publication_by_deduplication_key.rb
@@ -26,13 +26,13 @@ module SelfDeposit
       def find_publication_by_deduplication_key(deduplication_key:)
         @deduplication_key = deduplication_key
         raise ::Valkyrie::Persistence::ObjectNotFoundError unless resource
-        query_service.find_by(id: resource['id'])
+        @query_service.find_by(id: resource['id'])
       end
 
       # Queries Solr for a document that matches the provided key
       # @yield [Publication]
       def resource
-        @resource ||= @connection.get("select", params: { q: query, fl: "*", rows: 1 })["response"]["docs"].first
+        @connection.get("select", params: { q: query, fl: "*", rows: 1 })["response"]["docs"].first
       end
 
       # Solr query for for a Publication with a deduplication_key_tesi that matches the provided key

--- a/spec/importers/preservation_workflow_importer_spec.rb
+++ b/spec/importers/preservation_workflow_importer_spec.rb
@@ -25,12 +25,15 @@ RSpec.describe PreservationWorkflowImporter do
 
   describe "#import" do
     before do
-      persister.wipe!
       described_class.instance_variable_set(:@persister, persister)
       allow(Hyrax).to receive(:query_service).and_return(query_service)
       allow(Hyrax).to receive(:persister).and_return(persister)
-      publication
+      Hyrax.index_adapter.save(resource: publication)
       described_class.import(csv)
+    end
+
+    after do
+      Hyrax.index_adapter.wipe!
     end
 
     context "with new preservation_workflow for the work" do


### PR DESCRIPTION
- app/services/self_deposit/custom_queries/find_parent_works.rb: refactors query class to make comments clearer and remove unnecessary class distinctions.
- app/services/self_deposit/custom_queries/find_publication_by_deduplication_key.rb: makes this faster by using Solr instead of pulling all Fedora objects in the process of searching.
- spec/importers/preservation_workflow_importer_spec.rb: persists to Solr then wipes all of the records after each test.