### PR TITLE
Adds desired fields to Collection.

### DIFF
--- a/app/forms/collection_resource_form.rb
+++ b/app/forms/collection_resource_form.rb
@@ -3,6 +3,6 @@
 # Generated via
 #  `rails generate hyrax:collection_resource CollectionResource`
 class CollectionResourceForm < Hyrax::Forms::PcdmCollectionForm
-  include Hyrax::FormFields(:basic_metadata)
+  include Hyrax::FormFields(:emory_basic_metadata)
   include Hyrax::FormFields(:collection_resource)
 end

--- a/app/indexers/collection_resource_indexer.rb
+++ b/app/indexers/collection_resource_indexer.rb
@@ -3,6 +3,6 @@
 # Generated via
 #  `rails generate hyrax:collection_resource CollectionResource`
 class CollectionResourceIndexer < Hyrax::PcdmCollectionIndexer
-  include Hyrax::Indexer(:basic_metadata)
+  include Hyrax::Indexer(:emory_basic_metadata)
   include Hyrax::Indexer(:collection_resource)
 end

--- a/app/models/collection_resource.rb
+++ b/app/models/collection_resource.rb
@@ -27,6 +27,6 @@ class CollectionResource < Hyrax::PcdmCollection
   # * add Valkyrie attributes to this class
   # * update form and indexer to process the attributes
   #
-  include Hyrax::Schema(:basic_metadata)
+  include Hyrax::Schema(:emory_basic_metadata)
   include Hyrax::Schema(:collection_resource)
 end

--- a/config/metadata/collection_resource.yaml
+++ b/config/metadata/collection_resource.yaml
@@ -22,19 +22,41 @@
 #  `rails generate hyrax:collection_resource CollectionResource`
 
 attributes:
+  administrative_unit:
+    type: string
+    multiple: false
+    form:
+      primary: true
+      multiple: false
+    predicate: http://id.loc.gov/vocabulary/relators/cur
+  contact_information:
+    type: string
+    multiple: false
+    form:
+      primary: true
+      multiple: false
+    predicate: http://www.rdaregistry.info/Elements/u/#P60490
+  course:
+    type: string
+    form:
+      primary: false
+    predicate: http://hyrax-example.com/course
+  department:
+    type: string
+    form:
+      primary: true
+    predicate: http://hyrax-example.com/department
+  notes:
+    type: string
+    multiple: true
+    form:
+      primary: false
+      multiple: true
+    predicate: http://www.w3.org/2004/02/skos/core#note
   target_audience:
     type: string
     form:
       primary: true
       multiple: true
     predicate: http://hyrax-example.com/target_audience
-  department:
-    type: string
-    form:
-      primary: true
-    predicate: http://hyrax-example.com/department
-  course:
-    type: string
-    form:
-      primary: false
-    predicate: http://hyrax-example.com/course
+

--- a/config/metadata/emory_basic_metadata.yaml
+++ b/config/metadata/emory_basic_metadata.yaml
@@ -1,4 +1,4 @@
-# Override of basic_metadata.yaml in Hyrax v5.0.0.rc3
+# Override of basic_metadata.yaml in Hyrax v5.0.1
 #   Please be very careful in the changes made to this document.
 #   Generally, it is safe to alter the form options here (please
 #   match the "multiple" settings to the field level, which should
@@ -8,8 +8,32 @@
 #   persistence like the other settings.
 #
 # What has been changed:
-#   -`language` has been made a "primary" field (brings it out of
+#   - `language` has been made a "primary" field (brings it out of
 #      "Additional Fields").
+#   - `rights_statement` is now required.
+#   - `language` is now multiple.
+#   - `creator` is now maintaining the order of its array values.
+#   - `license` is no longer multiple nor required.
+#   - The following removed from the forms:
+#     - `alternative_title`
+#     - `arkivo_checksum`
+#     - `based_near`
+#     - `contributor`
+#     - `date_created`
+#     - `description`
+#     - `identifier`
+#     - `label`
+#     - `related_url`
+#     - `resource_type`
+#     - `source`
+#   - The following have been moved from Publication's YAML because they
+#     have been made common with Publication and Collection:
+#     - `holding_repository`
+#     - `institution`
+#     - `internal_rights_note`
+#     - `system_of_record_ID`
+#     - `emory_ark`
+#     - `staff_notes`
 ---
 attributes:
   abstract:
@@ -78,6 +102,24 @@ attributes:
     index_keys:
       - "description_tesim"
     predicate: http://purl.org/dc/elements/1.1/description
+  emory_ark:
+    type: string
+    multiple: true
+    form:
+      primary: true
+    index_keys:
+      - 'emory_ark_tesim'
+    predicate: http://id.loc.gov/vocabulary/identifiers/local#ark
+  holding_repository:
+    type: string
+    multiple: false
+    form:
+      primary: true
+      required: true
+      multiple: false
+    index_keys:
+      - 'holding_repository_tesi'
+    predicate: http://id.loc.gov/vocabulary/relators/rps
   identifier:
     type: string
     multiple: true
@@ -87,6 +129,24 @@ attributes:
   import_url:
     type: string
     predicate: http://scholarsphere.psu.edu/ns#importUrl
+  institution:
+    type: string
+    multiple: false
+    form:
+      primary: true
+      multiple: false
+    index_keys:
+      - 'institution_tesi'
+    predicate: http://rdaregistry.info/Elements/u/P60402
+  internal_rights_note:
+    type: string
+    multiple: false
+    form:
+      primary: true
+      multiple: false
+    index_keys:
+      - 'internal_rights_note_tesi'
+    predicate: http://metadata.emory.edu/vocab/cor-terms#internalRightsNote
   keyword:
     type: string
     multiple: true
@@ -166,6 +226,14 @@ attributes:
     index_keys:
       - "source_tesim"
     predicate: http://purl.org/dc/terms/source
+  staff_notes:
+    type: string
+    multiple: true
+    form:
+      primary: false
+    index_keys:
+      - 'staff_notes_tesim'
+    predicate: http://metadata.emory.edu/vocab/cor-terms#staffNote
   subject:
     type: string
     multiple: true
@@ -175,3 +243,12 @@ attributes:
     form:
       primary: false
     predicate: http://purl.org/dc/elements/1.1/subject
+  system_of_record_ID:
+    type: string
+    multiple: false
+    form:
+      primary: true
+      multiple: false
+    index_keys:
+      - 'system_of_record_ID_tesi'
+    predicate: http://metadata.emory.edu/vocab/cor-terms#descriptiveSystemID

--- a/config/metadata/publication_metadata.yaml
+++ b/config/metadata/publication_metadata.yaml
@@ -93,14 +93,6 @@ attributes:
     index_keys:
       - 'edition_tesi'
     predicate: http://id.loc.gov/ontologies/bibframe/editionStatement
-  emory_ark:
-    type: string
-    multiple: true
-    form:
-      primary: true
-    index_keys:
-      - 'emory_ark_tesim'
-    predicate: http://id.loc.gov/vocabulary/identifiers/local#ark
   emory_content_type:
     type: string
     multiple: false
@@ -136,34 +128,6 @@ attributes:
     index_keys:
       - 'grant_information_tesim'
     predicate: http://metadata.emory.edu/vocab/cor-terms#grantOrFundingNote
-  holding_repository:
-    type: string
-    multiple: false
-    form:
-      primary: true
-      required: true
-      multiple: false
-    index_keys:
-      - 'holding_repository_tesi'
-    predicate: http://id.loc.gov/vocabulary/relators/rps
-  institution:
-    type: string
-    multiple: false
-    form:
-      primary: true
-      multiple: false
-    index_keys:
-      - 'institution_tesi'
-    predicate: http://rdaregistry.info/Elements/u/P60402
-  internal_rights_note:
-    type: string
-    multiple: false
-    form:
-      primary: true
-      multiple: false
-    index_keys:
-      - 'internal_rights_note_tesi'
-    predicate: http://metadata.emory.edu/vocab/cor-terms#internalRightsNote
   issn:
     type: string
     multiple: false
@@ -286,23 +250,6 @@ attributes:
     index_keys:
       - 'sponsor_tesi'
     predicate: http://id.loc.gov/vocabulary/relators/spn
-  staff_notes:
-    type: string
-    multiple: true
-    form:
-      primary: false
-    index_keys:
-      - 'staff_notes_tesim'
-    predicate: http://metadata.emory.edu/vocab/cor-terms#staffNote
-  system_of_record_ID:
-    type: string
-    multiple: false
-    form:
-      primary: true
-      multiple: false
-    index_keys:
-      - 'system_of_record_ID_tesi'
-    predicate: http://metadata.emory.edu/vocab/cor-terms#descriptiveSystemID
   volume:
     type: string
     multiple: false

--- a/spec/forms/collection_resource_form_spec.rb
+++ b/spec/forms/collection_resource_form_spec.rb
@@ -10,4 +10,14 @@ RSpec.describe CollectionResourceForm do
   let(:resource)   { CollectionResource.new }
 
   it_behaves_like 'a Valkyrie::ChangeSet'
+
+  it 'has the expected fields' do
+    expect(change_set.fields.keys).to(
+      include(
+        "administrative_unit", "contact_information", "notes", "holding_repository",
+        "institution", "internal_rights_note", "system_of_record_ID", "emory_ark",
+        "staff_notes"
+      )
+    )
+  end
 end

--- a/spec/models/collection_resource_spec.rb
+++ b/spec/models/collection_resource_spec.rb
@@ -10,4 +10,10 @@ RSpec.describe CollectionResource do
 
   it_behaves_like 'a Hyrax::PcdmCollection'
   it_behaves_like 'a model with basic metadata'
+
+  ["administrative_unit", "contact_information", "notes", "holding_repository",
+   "institution", "internal_rights_note", "system_of_record_ID", "emory_ark",
+   "staff_notes"].each do |attr|
+    include_examples('checks model for new attribute response', attr)
+  end
 end

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -14,4 +14,10 @@ RSpec.describe Collection do
       expect(collection.human_readable_type).to eq 'Collection'
     end
   end
+
+  ["administrative_unit", "contact_information", "notes", "holding_repository",
+   "institution", "internal_rights_note", "system_of_record_ID", "emory_ark",
+   "staff_notes"].each do |attr|
+    include_examples('checks model for new attribute response', attr)
+  end
 end

--- a/spec/models/hyrax/file_metadata_spec.rb
+++ b/spec/models/hyrax/file_metadata_spec.rb
@@ -4,19 +4,8 @@ require 'rails_helper'
 RSpec.describe Hyrax::FileMetadata do
   subject(:file_metadata) { described_class.new }
 
-  describe '#original_checksum' do
-    it { is_expected.to respond_to(:original_checksum) }
-  end
-  describe '#file_path' do
-    it { is_expected.to respond_to(:file_path) }
-  end
-  describe '#puid' do
-    it { is_expected.to respond_to(:puid) }
-  end
-  describe '#creating_application_name' do
-    it { is_expected.to respond_to(:creating_application_name) }
-  end
-  describe '#creating_os' do
-    it { is_expected.to respond_to(:creating_os) }
+  ["original_checksum", "file_path", "puid", "creating_application_name",
+   "creating_os"].each do |attr|
+    include_examples('checks model for new attribute response', attr)
   end
 end

--- a/spec/support/shared_examples_for_models.rb
+++ b/spec/support/shared_examples_for_models.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'checks model for new attribute response' do |attribute_text|
+  describe "##{attribute_text}" do
+    it { is_expected.to respond_to(attribute_text.to_sym) }
+  end
+end


### PR DESCRIPTION
- app/forms/collection_resource_form.rb, app/indexers/collection_resource_indexer.rb, and app/models/collection_resource.rb: switches out YAML to our cusomized instance.
- config/metadata/collection_resource.yaml: brings in requested fields.
- config/metadata/emory_basic_metadata.yaml: makes fields in both Publication and Collection load from one common YAML.
- config/metadata/publication_metadata.yaml: moves repeated values into `emory_basic_metadata`.
- spec/*: programmatically tests for new fields.