### PR TITLE
Removes unnecessary fields from Collection's form.

### DIFF
--- a/app/forms/collection_resource_form.rb
+++ b/app/forms/collection_resource_form.rb
@@ -5,4 +5,14 @@
 class CollectionResourceForm < Hyrax::Forms::PcdmCollectionForm
   include Hyrax::FormFields(:emory_basic_metadata)
   include Hyrax::FormFields(:collection_resource)
+
+  def primary_terms
+    [:title, :creator, :emory_ark, :holding_repository, :institution,
+     :internal_rights_note, :system_of_record_ID, :administrative_unit,
+     :contact_information]
+  end
+
+  def secondary_terms
+    [:keyword, :rights_notes, :staff_notes, :subject, :notes]
+  end
 end

--- a/config/metadata/collection_resource.yaml
+++ b/config/metadata/collection_resource.yaml
@@ -36,16 +36,6 @@ attributes:
       primary: true
       multiple: false
     predicate: http://www.rdaregistry.info/Elements/u/#P60490
-  course:
-    type: string
-    form:
-      primary: false
-    predicate: http://hyrax-example.com/course
-  department:
-    type: string
-    form:
-      primary: true
-    predicate: http://hyrax-example.com/department
   notes:
     type: string
     multiple: true
@@ -53,10 +43,4 @@ attributes:
       primary: false
       multiple: true
     predicate: http://www.w3.org/2004/02/skos/core#note
-  target_audience:
-    type: string
-    form:
-      primary: true
-      multiple: true
-    predicate: http://hyrax-example.com/target_audience
 

--- a/spec/forms/collection_resource_form_spec.rb
+++ b/spec/forms/collection_resource_form_spec.rb
@@ -20,4 +20,14 @@ RSpec.describe CollectionResourceForm do
       )
     )
   end
+
+  it 'lacks the unnecessary fields' do
+    expect(change_set.primary_terms + change_set.secondary_terms).not_to(
+      include(
+        'rights_statement', 'target_audience', 'department', 'access_right', 'alternative_title',
+        'arkivo_checksum', 'abstract', 'identifier', 'publisher', 'label', 'language', 'license',
+        'related_url', 'resource_type', 'source', 'course'
+      )
+    )
+  end
 end


### PR DESCRIPTION
- app/forms/collection_resource_form.rb: hard-codes exactly what fields should be supplied to Collection's edit/new form.
- config/metadata/collection_resource.yaml: removes the fields given as examples from Hyrax' generator.
- spec/forms/collection_resource_form_spec.rb: tests for the lack of the undesired fields.