### PR TITLE
Moves attributes that shouldn't appear in Collections to Publication-specific YAML.

### DIFF
--- a/app/forms/generic_work_form.rb
+++ b/app/forms/generic_work_form.rb
@@ -8,7 +8,6 @@
 class GenericWorkForm < Hyrax::Forms::ResourceForm(GenericWork)
   include Hyrax::FormFields(:basic_metadata)
   include Hyrax::FormFields(:generic_work)
-  include Hyrax::FormFields(:publication_metadata)
 
   # Define custom form fields using the Valkyrie::ChangeSet interface
   #

--- a/app/models/generic_work.rb
+++ b/app/models/generic_work.rb
@@ -5,5 +5,4 @@
 class GenericWork < Hyrax::Work
   include Hyrax::Schema(:basic_metadata)
   include Hyrax::Schema(:generic_work)
-  include Hyrax::Schema(:publication_metadata)
 end

--- a/config/metadata/emory_basic_metadata.yaml
+++ b/config/metadata/emory_basic_metadata.yaml
@@ -44,15 +44,6 @@ attributes:
     index_keys:
       - "abstract_tesim"
     predicate: http://purl.org/dc/terms/abstract
-  access_right:
-    type: string
-    multiple: true
-    form:
-      primary: false
-      required: true
-    index_keys:
-      - "access_right_tesim"
-    predicate: http://purl.org/dc/terms/accessRights
   alternative_title:
     type: string
     multiple: true
@@ -170,15 +161,6 @@ attributes:
     index_keys:
       - "label_tesim"
     predicate: info:fedora/fedora-system:def/model#downloadFilename
-  language:
-    type: string
-    multiple: true
-    form:
-      primary: true
-      required: true
-    index_keys:
-      - "language_tesim"
-    predicate: http://purl.org/dc/elements/1.1/language
   license:
     type: string
     multiple: false
@@ -212,15 +194,6 @@ attributes:
     index_keys:
       - "rights_notes_tesim"
     predicate: http://purl.org/dc/elements/1.1/rights
-  rights_statement:
-    type: string
-    multiple: true
-    form:
-      primary: true
-      required: true
-    index_keys:
-      - "rights_statement_tesim"
-    predicate: http://www.europeana.eu/schemas/edm/rights
   source:
     type: string
     multiple: true

--- a/config/metadata/publication_metadata.yaml
+++ b/config/metadata/publication_metadata.yaml
@@ -19,6 +19,15 @@
 # @see config/metadata/basic_metadata.yaml for an example configuration
 
 attributes:
+  access_right:
+    type: string
+    multiple: true
+    form:
+      primary: false
+      required: true
+    index_keys:
+      - "access_right_tesim"
+    predicate: http://purl.org/dc/terms/accessRights
   author_notes:
     type: string
     multiple: false
@@ -155,6 +164,15 @@ attributes:
     index_keys:
       - 'issue_tesi'
     predicate: http://purl.org/ontology/bibo/issue
+  language:
+    type: string
+    multiple: true
+    form:
+      primary: true
+      required: true
+    index_keys:
+      - "language_tesim"
+    predicate: http://purl.org/dc/elements/1.1/language
   other_identifiers:
     type: string
     multiple: true
@@ -232,6 +250,15 @@ attributes:
     index_keys:
       - 'research_categories_tesim'
     predicate: http://metadata.emory.edu/vocab/cor-terms#researchCategories
+  rights_statement:
+    type: string
+    multiple: true
+    form:
+      primary: true
+      required: true
+    index_keys:
+      - "rights_statement_tesim"
+    predicate: http://www.europeana.eu/schemas/edm/rights
   series_title:
     type: string
     multiple: false

--- a/spec/models/collection_resource_spec.rb
+++ b/spec/models/collection_resource_spec.rb
@@ -9,7 +9,62 @@ RSpec.describe CollectionResource do
   subject(:collection) { described_class.new }
 
   it_behaves_like 'a Hyrax::PcdmCollection'
-  it_behaves_like 'a model with basic metadata'
+
+  it 'has abstracts' do
+    expect { collection.abstract = ['lorem ipsum', 'a story about moomins'] }
+      .to change { collection.abstract }
+      .to contain_exactly 'lorem ipsum', 'a story about moomins'
+  end
+
+  it 'has a label' do
+    expect { collection.label = 'one single label' }
+      .to change { collection.label }
+      .to eq 'one single label'
+  end
+
+  it 'has licenses' do
+    expect { collection.license = ['http://example.com/li1', 'http://example.com/li2'] }
+      .to change { collection.license }
+      .to contain_exactly 'http://example.com/li1', 'http://example.com/li2'
+  end
+
+  it 'has a relative path' do
+    expect { collection.relative_path = 'hamburger' }
+      .to change { collection.relative_path }
+      .to eq 'hamburger'
+  end
+
+  it 'has resource types' do
+    expect { collection.resource_type = ['book', 'image'] }
+      .to change { collection.resource_type }
+      .to contain_exactly 'book', 'image'
+  end
+
+  it 'has rights notes' do
+    expect { collection.rights_notes = ['secret', 'do not use'] }
+      .to change { collection.rights_notes }
+      .to contain_exactly 'secret', 'do not use'
+  end
+
+  it 'has sources' do
+    expect { collection.source = ['first', 'second'] }
+      .to change { collection.source }
+      .to contain_exactly 'first', 'second'
+  end
+
+  it 'has subjects' do
+    expect { collection.subject = ['moomin', 'snork'] }
+      .to change { collection.subject }
+      .to contain_exactly 'moomin', 'snork'
+  end
+
+  it 'does not have language' do
+    expect(collection).not_to respond_to(:language)
+  end
+
+  it 'does not have rights statements' do
+    expect(collection).not_to respond_to(:rights_statement)
+  end
 
   ["administrative_unit", "contact_information", "notes", "holding_repository",
    "institution", "internal_rights_note", "system_of_record_ID", "emory_ark",


### PR DESCRIPTION
- app/forms/generic_work_form.rb and app/models/generic_work.rb: removed publication YAML because collisions were occurring.
- config/metadata/emory_basic_metadata.yaml: removes fields that truly aren't common among Publication and Collection.
- config/metadata/publication_metadata.yaml: moves fields removed above to this YAML.
- spec/models/collection_resource_spec.rb: alters tests inclusion because `language` and `rights_statement`. Instead, tests are brought over directly and altered if field should be missing.