### PR TITLE
Move description to collection resource metadata yaml

### DIFF
--- a/config/metadata/collection_resource.yaml
+++ b/config/metadata/collection_resource.yaml
@@ -36,6 +36,15 @@ attributes:
       primary: true
       multiple: false
     predicate: http://www.rdaregistry.info/Elements/u/#P60490
+  description:
+    type: string
+    multiple: true
+    form:
+      required: true
+      primary: true
+    index_keys:
+      - "description_tesim"
+    predicate: http://purl.org/dc/elements/1.1/description
   notes:
     type: string
     multiple: true

--- a/config/metadata/emory_basic_metadata.yaml
+++ b/config/metadata/emory_basic_metadata.yaml
@@ -89,15 +89,6 @@ attributes:
     index_keys:
       - "date_created_tesim"
     predicate: http://purl.org/dc/terms/created
-  description:
-    type: string
-    multiple: true
-    form:
-      required: true
-      primary: true
-    index_keys:
-      - "description_tesim"
-    predicate: http://purl.org/dc/elements/1.1/description
   emory_ark:
     type: string
     multiple: true


### PR DESCRIPTION
Fixes #309 

Even though description is not used in the publication form, having it defined in the basic metadata file causes issues with saving a publication. The underlying problem is that description cannot be saved as empty if defined in the basic metadata file used by publication and collection creation. I am moving description to the collection metadata to resolve this issue, since the publication form does not use a description attribute.