### PR TITLE
Adds devise_saml_authenticatable.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'coffee-rails', '~> 4.2'
 gem 'dalli'
 gem 'devise'
 gem 'devise-guests', '~> 0.8'
+gem "devise_saml_authenticatable", git: "https://github.com/apokalipto/devise_saml_authenticatable"
 gem 'dotenv-rails'
 gem 'hydra-role-management'
 gem 'hyrax', '5.0.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,12 @@
 GIT
+  remote: https://github.com/apokalipto/devise_saml_authenticatable
+  revision: f8a85c3f3ed069fd40701424e2eef075219ef17f
+  specs:
+    devise_saml_authenticatable (1.9.1)
+      devise (> 2.0.0)
+      ruby-saml (~> 1.7)
+
+GIT
   remote: https://github.com/brentd/xray-rails
   revision: f121814718c9907b20058dc9357b80a53afab821
   branch: bugs/ruby-3.0.0
@@ -912,6 +920,9 @@ GEM
       multipart-post
       oauth2
     ruby-progressbar (1.13.0)
+    ruby-saml (1.16.0)
+      nokogiri (>= 1.13.10)
+      rexml
     ruby2_keywords (0.0.5)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
@@ -1097,6 +1108,7 @@ DEPENDENCIES
   debug (>= 1.0.0)
   devise
   devise-guests (~> 0.8)
+  devise_saml_authenticatable!
   dotenv-rails
   ed25519 (>= 1.2, < 2.0)
   factory_bot_rails

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,7 +12,7 @@ class User < ApplicationRecord
   include Blacklight::User
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
-  devise :database_authenticatable, :registerable,
+  devise :database_authenticatable, :saml_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
   # Method added by Blacklight; Blacklight uses #to_s on your

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -308,4 +308,20 @@ Devise.setup do |config|
   # When set to false, does not sign a user in automatically after their password is
   # changed. Defaults to true, so a user is signed in automatically after changing a password.
   # config.sign_in_after_change_password = true
+
+  config.saml_route_helper_prefix = 'saml'
+
+  # Configure with your SAML settings (see ruby-saml's README for more information: https://github.com/onelogin/ruby-saml).
+  config.saml_configure do |settings|
+    settings.assertion_consumer_service_url     = "https://shib.open.library.emory.edu/Shibboleth.sso/SAML2/POST"
+    settings.assertion_consumer_service_binding = "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
+    settings.name_identifier_format             = "urn:oasis:names:tc:SAML:2.0:nameid-format:transient" # unchanged
+    settings.sp_entity_id                       = "https://shib.open.library.emory.edu"
+    settings.authn_context                      = "" # unchanged
+    settings.idp_slo_service_url                = "https://shib.open.library.emory.edu/Shibboleth.sso/SLO/POST"
+    settings.idp_sso_service_url                = "https://shib.open.library.emory.edu/Shibboleth.sso/Login"
+    # used the use="signing" key below
+    settings.idp_cert_fingerprint               = ENV['IDP_CERT_FINGERPRINT']
+    settings.idp_cert_fingerprint_algorithm     = "http://www.w3.org/2000/09/xmldsig#sha1" # unchanged
+  end
 end


### PR DESCRIPTION
- Gemfile*: installs the gem.
- app/models/user.rb: allows SAML authentication (please note that order is very important here. Database Auth must always be mentioned first.)
- config/initializers/devise.rb: stubs approximated settings values.