### PR TITLE
Corrects the PURL Controller issues.

### DIFF
--- a/app/controllers/purl_controller.rb
+++ b/app/controllers/purl_controller.rb
@@ -2,14 +2,17 @@
 class PurlController < ApplicationController
   def redirect_to_original
     purl_object = Hyrax.custom_queries.find_by_alternate_id(alternate_ids: params[:alternate_ids])
-    if purl_object.has_model.present? && purl_object.has_model.first == 'Publication'
+
+    if purl_object.work?
       object_url = "#{request.base_url}/concern/publications/#{purl_object.id}"
       redirect_to object_url
-    elsif purl_object.respond_to?(:collection_type_gid) && purl_object.collection_type_gid.present?
+    elsif purl_object.collection?
       object_url = "#{request.base_url}/collections/#{purl_object.id}"
       redirect_to object_url
     else
       render plain: 'Item not found', status: :not_found
     end
+  rescue
+    render plain: 'Item not found', status: :not_found
   end
 end

--- a/app/services/self_deposit/custom_queries/find_by_alternate_id.rb
+++ b/app/services/self_deposit/custom_queries/find_by_alternate_id.rb
@@ -20,7 +20,7 @@ module SelfDeposit
       end
 
       def resource
-        @connection.get("select", params: { q: "*:*", fl: "*", rows: 1 })["response"]["docs"].first
+        @connection.get("select", params: { q: query, fl: "*", rows: 1 })["response"]["docs"].first
       end
 
       def query

--- a/app/services/self_deposit/custom_queries/find_by_alternate_id.rb
+++ b/app/services/self_deposit/custom_queries/find_by_alternate_id.rb
@@ -1,18 +1,14 @@
 # frozen_string_literal: true
-module SelfDeposit
-  module CustomQueries
-    class FindByAlternateId < SolrDocumentQuery
-      self.queries = [:find_by_alternate_id]
+class SelfDeposit::CustomQueries::FindByAlternateId < ::SelfDeposit::CustomQueries::SolrDocumentQuery
+  self.queries = [:find_by_alternate_id]
 
-      def find_by_alternate_id(alternate_ids:)
-        @alternate_id = alternate_ids
-        raise ::Valkyrie::Persistence::ObjectNotFoundError unless resource
-        @query_service.find_by(id: resource['id'])
-      end
+  def find_by_alternate_id(alternate_ids:)
+    @alternate_id = alternate_ids
+    raise ::Valkyrie::Persistence::ObjectNotFoundError unless resource
+    @query_service.find_by(id: resource['id'])
+  end
 
-      def query
-        "alternate_ids_ssim:#{@alternate_id}"
-      end
-    end
+  def query
+    "alternate_ids_ssim:#{@alternate_id}"
   end
 end

--- a/app/services/self_deposit/custom_queries/find_by_alternate_id.rb
+++ b/app/services/self_deposit/custom_queries/find_by_alternate_id.rb
@@ -1,26 +1,15 @@
 # frozen_string_literal: true
 module SelfDeposit
   module CustomQueries
-    class FindByAlternateId
+    class FindByAlternateId < SolrDocumentQuery
       def self.queries
         [:find_by_alternate_id]
       end
-
-      def initialize(query_service:)
-        @query_service = query_service
-        @connection = Hyrax.index_adapter.connection
-      end
-
-      attr_reader :query_service
 
       def find_by_alternate_id(alternate_ids:)
         @alternate_id = alternate_ids
         raise ::Valkyrie::Persistence::ObjectNotFoundError unless resource
         @query_service.find_by(id: resource['id'])
-      end
-
-      def resource
-        @connection.get("select", params: { q: query, fl: "*", rows: 1 })["response"]["docs"].first
       end
 
       def query

--- a/app/services/self_deposit/custom_queries/find_by_alternate_id.rb
+++ b/app/services/self_deposit/custom_queries/find_by_alternate_id.rb
@@ -2,9 +2,7 @@
 module SelfDeposit
   module CustomQueries
     class FindByAlternateId < SolrDocumentQuery
-      def self.queries
-        [:find_by_alternate_id]
-      end
+      self.queries = [:find_by_alternate_id]
 
       def find_by_alternate_id(alternate_ids:)
         @alternate_id = alternate_ids

--- a/app/services/self_deposit/custom_queries/find_by_source_identifier.rb
+++ b/app/services/self_deposit/custom_queries/find_by_source_identifier.rb
@@ -9,9 +9,7 @@ module SelfDeposit
     #
     # @see https://github.com/samvera/valkyrie/wiki/Queries#custom-queries
     class FindBySourceIdentifier < SolrDocumentQuery
-      def self.queries
-        [:find_by_model_and_property_value]
-      end
+      self.queries = [:find_by_model_and_property_value]
 
       ##
       # @param model [Class, #internal_resource]

--- a/app/services/self_deposit/custom_queries/find_by_source_identifier.rb
+++ b/app/services/self_deposit/custom_queries/find_by_source_identifier.rb
@@ -8,17 +8,10 @@ module SelfDeposit
     #   Hyrax.query_service.custom_queries.find_by_model_and_property_value(model:, property: :deduplication_key, value: 'jhqsdhdwhcolh')
     #
     # @see https://github.com/samvera/valkyrie/wiki/Queries#custom-queries
-    class FindBySourceIdentifier
+    class FindBySourceIdentifier < SolrDocumentQuery
       def self.queries
         [:find_by_model_and_property_value]
       end
-
-      def initialize(query_service:)
-        @query_service = query_service
-        @connection = Hyrax.index_adapter.connection
-      end
-
-      attr_reader :query_service
 
       ##
       # @param model [Class, #internal_resource]
@@ -34,12 +27,6 @@ module SelfDeposit
 
         return if resource.blank?
         @query_service.find_by(id: resource['id'])
-      end
-
-      # Queries Solr for a document that matches the provided key
-      # @yield [Publication]
-      def resource
-        @connection.get("select", params: { q: query, fl: "*", rows: 1 })["response"]["docs"]&.first
       end
 
       # Solr query for for a Publication with a deduplication_key_tesi that matches the provided key

--- a/app/services/self_deposit/custom_queries/find_publication_by_deduplication_key.rb
+++ b/app/services/self_deposit/custom_queries/find_publication_by_deduplication_key.rb
@@ -8,9 +8,7 @@ module SelfDeposit
     #
     # @see https://github.com/samvera/valkyrie/wiki/Queries#custom-queries
     class FindPublicationByDeduplicationKey < SolrDocumentQuery
-      def self.queries
-        [:find_publication_by_deduplication_key]
-      end
+      self.queries = [:find_publication_by_deduplication_key]
 
       ##
       # @param deduplication_key for a Publication

--- a/app/services/self_deposit/custom_queries/find_publication_by_deduplication_key.rb
+++ b/app/services/self_deposit/custom_queries/find_publication_by_deduplication_key.rb
@@ -7,17 +7,10 @@ module SelfDeposit
     #   Hyrax.custom_queries.find_publication_by_deduplication_key(deduplication_key:)
     #
     # @see https://github.com/samvera/valkyrie/wiki/Queries#custom-queries
-    class FindPublicationByDeduplicationKey
+    class FindPublicationByDeduplicationKey < SolrDocumentQuery
       def self.queries
         [:find_publication_by_deduplication_key]
       end
-
-      def initialize(query_service:)
-        @query_service = query_service
-        @connection = Hyrax.index_adapter.connection
-      end
-
-      attr_reader :query_service
 
       ##
       # @param deduplication_key for a Publication
@@ -27,12 +20,6 @@ module SelfDeposit
         @deduplication_key = deduplication_key
         raise ::Valkyrie::Persistence::ObjectNotFoundError unless resource
         @query_service.find_by(id: resource['id'])
-      end
-
-      # Queries Solr for a document that matches the provided key
-      # @yield [Publication]
-      def resource
-        @connection.get("select", params: { q: query, fl: "*", rows: 1 })["response"]["docs"].first
       end
 
       # Solr query for for a Publication with a deduplication_key_tesi that matches the provided key

--- a/app/services/self_deposit/custom_queries/solr_document_query.rb
+++ b/app/services/self_deposit/custom_queries/solr_document_query.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+module SelfDeposit
+  module CustomQueries
+    class SolrDocumentQuery
+      def initialize(query_service:)
+        @query_service = query_service
+        @connection = Hyrax.index_adapter.connection
+      end
+
+      attr_reader :query_service
+
+      # Queries Solr for a document that matches the provided key
+      # @yield [Publication]
+      def resource
+        @connection.get("select", params: { q: query, fl: "*", rows: 1 })["response"]["docs"].first
+      end
+    end
+  end
+end

--- a/app/services/self_deposit/custom_queries/solr_document_query.rb
+++ b/app/services/self_deposit/custom_queries/solr_document_query.rb
@@ -7,6 +7,7 @@ module SelfDeposit
         @connection = Hyrax.index_adapter.connection
       end
 
+      class_attribute :queries
       attr_reader :query_service
 
       # Queries Solr for a document that matches the provided key


### PR DESCRIPTION
- app/controllers/purl_controller.rb: `#has_model` only applies to ActiveFedora objects, not Valkyrie instances. Also avoids a 500 error by rescuing with the message provided.
- app/services/self_deposit/custom_queries/find_by_alternate_id.rb: adds query that was never passed in.
- spec/controllers/purl_controller_spec.rb: tests true Collection and Publication objects for redirecting.