### PR TITLE
Adds EFS file locating to CSV-only Bulkrax importer.

### DIFF
--- a/app/models/concerns/bulkrax/has_local_processing.rb
+++ b/app/models/concerns/bulkrax/has_local_processing.rb
@@ -12,6 +12,7 @@ module Bulkrax::HasLocalProcessing
     parsed_metadata['publisher'] = parsed_metadata['publisher'].blank? ? 'Emory University Libraries' : parsed_metadata['publisher'].strip
 
     process_emory_content_type
+    point_file_location_to_efs
   end
 
   def process_emory_content_type
@@ -20,5 +21,11 @@ module Bulkrax::HasLocalProcessing
     pulled_type = authority.all.find { |v| v['label'] == parsed_metadata['emory_content_type']&.strip&.titleize }
 
     parsed_metadata['emory_content_type'] = pulled_type.present? ? pulled_type['id'] : default_type
+  end
+
+  def point_file_location_to_efs
+    return if importer.zip?
+
+    parsed_metadata['file'] = Dir.glob("/mnt/efs/current_batch/emory_#{parsed_metadata['deduplication_key']}/*")
   end
 end

--- a/lib/metadata/mods_metadata_extraction_methods.rb
+++ b/lib/metadata/mods_metadata_extraction_methods.rb
@@ -24,7 +24,7 @@ module ModsMetadataExtractionMethods
                           end
     end
     @ret_hash['file'] = @pids_and_filenames[@pid]
-    @ret_hash['pid'] = @pid
+    @ret_hash['deduplication_key'] = @pid
   end
 
   def create_csv_from_ret_hash_array

--- a/spec/features/bulkrax_csv_import_spec.rb
+++ b/spec/features/bulkrax_csv_import_spec.rb
@@ -8,27 +8,27 @@ RSpec.describe 'Bulkrax CSV importer', :clean_repo, type: :feature do
     let(:all_mapped_fields) do
       ["abstract", "author_notes", "conference_name", "content_genre", "creator", "creator_last_first",
        "data_classification", "date_issued", "date_issue_year", "deduplication_key", "edition", "emory_content_type",
-       "emory_ark", "file", "file_labels", "final_published_versions", "grant_agencies", "grant_information",
+       "emory_ark", "file", "final_published_versions", "grant_agencies", "grant_information",
        "holding_repository", "institution", "internal_rights_note", "isbn", "issn", "issue", "keyword", "language",
        "license", "model", "page_range_end", "page_range_start", "parent", "parent_title", "place_of_production",
        "publisher", "publisher_version", "related_datasets", "research_categories", "rights_notes", "rights_statement",
        "series_title", "sponsor", "staff_notes", "subject", "system_of_record_ID", "title", "volume"]
     end
     let(:multiple_value_fields) do
-      ["abstract", "creator", "creator_last_first", "emory_ark", "file", "file_labels", "final_published_versions",
+      ["abstract", "creator", "creator_last_first", "emory_ark", "file", "final_published_versions",
        "grant_agencies", "grant_information", "keyword", "related_datasets", "research_categories", "rights_notes",
        "rights_statement", "staff_notes", "subject", "title"]
     end
 
     it 'maps the expected fields' do
-      expect(pulled_field_mappings.count).to eq(46)
+      expect(pulled_field_mappings.count).to eq(45)
       expect(pulled_field_mappings.keys).to match_array(all_mapped_fields)
     end
 
     it 'contains the expected multivalue fields' do
       multivalued_fields = pulled_field_mappings.select { |_k, v| v[:split].present? }
 
-      expect(multivalued_fields.count).to eq(17)
+      expect(multivalued_fields.count).to eq(16)
       expect(multivalued_fields.keys).to match_array(multiple_value_fields)
     end
   end

--- a/spec/lib/metadata/mods_metadata_to_csv_extractor_spec.rb
+++ b/spec/lib/metadata/mods_metadata_to_csv_extractor_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe ModsMetadataToCsvExtractor, :clean do
             "AUDIT.xml;DC.xml;RELS-EXT.xml;SYMPLECTIC-ATOM.xml;Prinz_2007_systematic-computational-exploration-of-the-parameter" \
             "-space-of-the-multi-compartment-modeTRUNCATED_FILE_NAME.pdf;emoryFIRSTLicense1.odt;descMetadata.xml;content.pdf;" \
             "provenanceMetadata.xml",
-          "pid" => "td5xw" }
+          "deduplication_key" => "td5xw" }
       )
     end
   end


### PR DESCRIPTION
- app/models/concerns/bulkrax/has_local_processing.rb: inserts method that adds all files within a PID's EFS folder to the CsvEntry `file` attribute only if the importer isn't using a zip file.
- config/initializers/bulkrax.rb: removes the responsibility of assigning filenames/labels from the CSV document and only alters the filename if the file represents the main `content` document. 
- lib/metadata/mods_metadata_extraction_methods.rb: since we'll be using the PID as the `deduplication_key`, no need to have it assigned to a separate column.
- spec/*: updates expectations.