### PR TITLE
Alters the internal Bulkrax file location for our purposes.

### DIFF
--- a/app/models/concerns/bulkrax/has_local_processing.rb
+++ b/app/models/concerns/bulkrax/has_local_processing.rb
@@ -12,7 +12,7 @@ module Bulkrax::HasLocalProcessing
     parsed_metadata['publisher'] = parsed_metadata['publisher'].blank? ? 'Emory University Libraries' : parsed_metadata['publisher'].strip
 
     process_emory_content_type
-    point_file_location_to_efs
+    # point_file_location_to_efs
   end
 
   def process_emory_content_type

--- a/app/models/concerns/bulkrax/has_local_processing.rb
+++ b/app/models/concerns/bulkrax/has_local_processing.rb
@@ -12,7 +12,6 @@ module Bulkrax::HasLocalProcessing
     parsed_metadata['publisher'] = parsed_metadata['publisher'].blank? ? 'Emory University Libraries' : parsed_metadata['publisher'].strip
 
     process_emory_content_type
-    # point_file_location_to_efs
   end
 
   def process_emory_content_type
@@ -21,11 +20,5 @@ module Bulkrax::HasLocalProcessing
     pulled_type = authority.all.find { |v| v['label'] == parsed_metadata['emory_content_type']&.strip&.titleize }
 
     parsed_metadata['emory_content_type'] = pulled_type.present? ? pulled_type['id'] : default_type
-  end
-
-  def point_file_location_to_efs
-    return if importer.zip?
-
-    parsed_metadata['file'] = Dir.glob("/mnt/efs/current_batch/emory_#{parsed_metadata['deduplication_key']}/*")
   end
 end

--- a/config/initializers/bulkrax.rb
+++ b/config/initializers/bulkrax.rb
@@ -268,7 +268,11 @@ Rails.application.config.to_prepare do
         next if r[file_mapping].blank?
 
         r[file_mapping].split(Bulkrax.multi_value_element_split_on).map do |f|
-          file = File.join(path_to_files(pid: r[:deduplication_key]), f.tr(' ', '_'))
+          file = if zip?
+                   File.join(path_to_files, f.tr(' ', '_'))
+                 else
+                   File.join(path_to_files, "emory_#{r[:deduplication_key]}", f.tr(' ', '_'))
+                 end
           if File.exist?(file) # rubocop:disable Style/GuardClause
             file
           else
@@ -281,11 +285,10 @@ Rails.application.config.to_prepare do
     # Retrieve the path where we expect to find the files
     def path_to_files(**args)
       filename = args.fetch(:filename, '')
-      pid = args.fetch(:pid, '')
 
       return @path_to_files if @path_to_files.present? && filename.blank?
       @path_to_files = File.join(
-        zip? ? importer_unzip_path : '/mnt/efs/current_batch', "emory_#{pid}", filename
+        zip? ? importer_unzip_path : '/mnt/efs/current_batch'
       )
     end
   end

--- a/config/initializers/bulkrax.rb
+++ b/config/initializers/bulkrax.rb
@@ -292,4 +292,16 @@ Rails.application.config.to_prepare do
       )
     end
   end
+
+  Bulkrax::CsvEntry.class_eval do
+    # If only filename is given, construct the path (/files/my_file)
+    def path_to_file(file)
+      # return if we already have the full file path
+      return file if File.exist?(file)
+      path = importerexporter.parser.path_to_files
+      f = parser.zip? ? File.join(path, file) : File.join(path, "emory_#{@record['deduplication_key']}", file)
+      return f if File.exist?(f)
+      raise "File #{f} does not exist"
+    end
+  end
 end


### PR DESCRIPTION
- app/models/concerns/bulkrax/has_local_processing.rb: removes file locating logic from local processing concern because CsvParser processes file locating way before that concern is called.
- app/models/concerns/bulkrax/has_local_processing.rb: overrides the following methods,
  - `#file_paths`: utilizes our added custom method to pull and verify the file locations.
  - `#pull_file_mapping`: refactors this logic to its own method to lower Cyclomatic Complexity.
  - `#locate_files_for_record`: another of our own methods that abstracts the logic to test and pull the file locations.
  - `#path_to_files` and `Bulkrax::CsvEntry#path_to_file`: hard-codes the EFS mount path instead of a passed variable.
  