### PR TITLE
Updates and alters the display of index metadata.

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -71,24 +71,11 @@ class CatalogController < ApplicationController
     # solr fields to be displayed in the index (search results) view
     #   The ordering of the field names is the order of the display
     config.add_index_field "title_tesim", label: "Title", itemprop: 'name', if: false
-    config.add_index_field "description_tesim", itemprop: 'description', helper_method: :iconify_auto_link
-    config.add_index_field "keyword_tesim", itemprop: 'keywords', link_to_facet: "keyword_sim"
-    config.add_index_field "subject_tesim", itemprop: 'about', link_to_facet: "subject_sim"
-    config.add_index_field "creator_tesim", itemprop: 'creator', link_to_facet: "creator_sim"
-    config.add_index_field "contributor_tesim", itemprop: 'contributor', link_to_facet: "contributor_sim"
-    config.add_index_field "proxy_depositor_ssim", label: "Depositor", helper_method: :link_to_profile
-    config.add_index_field "depositor_tesim", label: "Owner", helper_method: :link_to_profile
-    config.add_index_field "publisher_tesim", itemprop: 'publisher', link_to_facet: "publisher_sim"
-    config.add_index_field "based_near_label_tesim", itemprop: 'contentLocation', link_to_facet: "based_near_label_sim"
-    config.add_index_field "language_tesim", itemprop: 'inLanguage', link_to_facet: "language_sim"
-    config.add_index_field "date_uploaded_dtsi", itemprop: 'datePublished', helper_method: :human_readable_date
-    config.add_index_field "date_modified_dtsi", itemprop: 'dateModified', helper_method: :human_readable_date
-    config.add_index_field "date_created_tesim", itemprop: 'dateCreated'
-    config.add_index_field "rights_statement_tesim", helper_method: :rights_statement_links
-    config.add_index_field "license_tesim", helper_method: :license_links
-    config.add_index_field "resource_type_tesim", label: "Resource Type", link_to_facet: "resource_type_sim"
-    config.add_index_field "file_format_tesim", link_to_facet: "file_format_sim"
-    config.add_index_field "identifier_tesim", helper_method: :index_field_link, field_name: 'identifier'
+    config.add_index_field "creator_ssim", label: 'Authors', itemprop: 'creator', helper_method: :emory_creators_display
+    config.add_index_field "date_issued_year_tesi", label: "Date"
+    config.add_index_field "publisher_tesim", itemprop: 'publisher'
+    config.add_index_field "publisher_version_tesi", itemprop: 'publisherVersion', label: 'Publication Version'
+    config.add_index_field "license_tesi", helper_method: :license_links, label: 'License'
     config.add_index_field Hydra.config.permissions.embargo.release_date, label: "Embargo release date", helper_method: :human_readable_date
     config.add_index_field Hydra.config.permissions.lease.expiration_date, label: "Lease expiration date", helper_method: :human_readable_date
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,3 +1,24 @@
 # frozen_string_literal: true
 module ApplicationHelper
+  def emory_creators_display(presenter)
+    values = presenter.is_a?(Hash) ? presenter[:value] : presenter.solr_document['creator_ssim']
+
+    safe_join(
+      values.map do |author|
+        author_array = author.split(',').map(&:strip)
+        author_span = if author_array.length > 3
+                        sanitize("<span itemprop='name'>#{author_array[0]} #{author_array[1]} #{orcid_link_for_creator(author_array[3])}, #{author_array[2]}</span>")
+                      else
+                        tag.span([author_array[0], "#{author_array[1]},", author_array[2]].join(' '), itemprop: 'name')
+                      end
+
+        content_tag(:li, author_span, itemprop: 'creator', itemscope: '', itemtype: 'http://schema.org/Person', class: 'attribute attribute-creator')
+      end
+    )
+  end
+
+  def orcid_link_for_creator(orcid_id)
+    link_to(image_tag("https://info.orcid.org/wp-content/uploads/2019/11/orcid_16x16.png", alt: 'ORCID logo', size: "16"),
+            "https://orcid.org/#{orcid_id}")
+  end
 end

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -1,5 +1,5 @@
-<!-- Hyrax v5.0.1 Override - the fields below are no longer dynamically delivered via Hyrax' config settings.-->
-    Instead, they are hard coded here. We, in turn, have overridden this partial so we can institute our own choices/order. %>
+<!-- Hyrax v5.0.1 Override - the fields below are no longer dynamically delivered via Hyrax' config settings.
+       Instead, they are hard coded here. We, in turn, have overridden this partial so we can institute our own choices/order. -->
 <% generic_renderer = ::Hyrax::Renderers::AttributeRenderer %>
 <% facet_renderer = ::Hyrax::Renderers::FacetedAttributeRenderer %>
 <% content_type_term = SelfDeposit::ContentTypesService.label(presenter.solr_document['emory_content_type_tesi']) %>

--- a/app/views/hyrax/base/_creator.html.erb
+++ b/app/views/hyrax/base/_creator.html.erb
@@ -1,18 +1,6 @@
 <dt>Authors</dt>
 <dd>
   <ul class="tabular">
-  <% presenter.solr_document['creator_ssim'].each do |author| %>
-    <% author_array = author.split(',').map(&:strip) %>
-        <li itemprop="creator" itemscope="" itemtype="http://schema.org/Person" class="attribute attribute-creator"> 
-            <% if author_array.length > 3 %>
-            <span itemprop="name"><%= author_array[0] %> <%= author_array[1] %>
-              <a href="https://orcid.org/<%= author_array[3] %>">
-                <img alt="ORCID logo" src="https://info.orcid.org/wp-content/uploads/2019/11/orcid_16x16.png" width="16" height="16" />
-              </a>, <%= author_array[2] %></span>
-            <% else %>
-                <span itemprop="name"><%= author_array[0] %> <%= author_array[1] %>, <%= author_array[2] %></span>
-            <% end %>
-        </li>
-    <% end %>
+    <%= emory_creators_display(presenter) %>
   </ul>
 </dd>


### PR DESCRIPTION
- app/controllers/catalog_controller.rb: removes and updates fields that are displayed in the search index page.
- app/helpers/application_helper.rb: abstracts the display of the creators field so that it serves two locations.
- app/views/hyrax/base/_attribute_rows.html.erb: fixes the formatting of a comment.
- app/views/hyrax/base/_creator.html.erb: switches out the interpolated HTML to the newly created helper.