### PR TITLE
Reconfigures the rspec test instances to pass locally.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,7 @@ jobs:
       HYRAX_VALKYRIE: true
       RACK_ENV: test
       RAILS_ENV: test
+      RAILS_ROOT: .
       SOLR_TEST_URL: http://127.0.0.1:8983/solr/dlp-selfdeposit-test
       SPEC_OPTS: >-
         --profile 10 --format RspecJunitFormatter --out /tmp/test-results/rspec.xml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,7 @@ jobs:
       DB_NAME: dlp-selfdeposit-test
       DB_PASSWORD: hyrax_password
       DB_PORT: 5432
+      DATABASE_TEST_URL: postgresql://hyrax_user:hyrax_password@127.0.0.1:5432/dlp-selfdeposit-test?pool=5
       DB_USERNAME: hyrax_user
       FCREPO_TEST_PORT: 8080
       FCREPO_URL: http://fedoraAdmin:fedoraAdmin@127.0.0.1:8080/fcrepo/rest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,14 +46,12 @@ jobs:
       DB_NAME: dlp-selfdeposit-test
       DB_PASSWORD: hyrax_password
       DB_PORT: 5432
-      DATABASE_TEST_URL: postgresql://hyrax_user:hyrax_password@127.0.0.1:5432/dlp-selfdeposit-test?pool=5
       DB_USERNAME: hyrax_user
       FCREPO_TEST_PORT: 8080
       FCREPO_URL: http://fedoraAdmin:fedoraAdmin@127.0.0.1:8080/fcrepo/rest
       HYRAX_VALKYRIE: true
       RACK_ENV: test
       RAILS_ENV: test
-      RAILS_ROOT: .
       SOLR_TEST_URL: http://127.0.0.1:8983/solr/dlp-selfdeposit-test
       SPEC_OPTS: >-
         --profile 10 --format RspecJunitFormatter --out /tmp/test-results/rspec.xml

--- a/Gemfile
+++ b/Gemfile
@@ -61,6 +61,7 @@ group :development, :test do
   gem 'bixby'
   gem 'capybara-screenshot'
   gem 'coveralls', require: false
+  gem 'database_cleaner'
   gem 'debug', '>= 1.0.0'
   gem 'factory_bot_rails'
   gem 'pry-doc'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -322,6 +322,12 @@ GEM
     crass (1.0.6)
     csv (3.3.0)
     dalli (3.2.8)
+    database_cleaner (2.0.2)
+      database_cleaner-active_record (>= 2, < 3)
+    database_cleaner-active_record (2.2.0)
+      activerecord (>= 5.a)
+      database_cleaner-core (~> 2.0.0)
+    database_cleaner-core (2.0.1)
     date (3.3.4)
     debug (1.9.2)
       irb (~> 1.10)
@@ -1256,6 +1262,7 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   coveralls
   dalli
+  database_cleaner
   debug (>= 1.0.0)
   devise
   devise-guests (~> 0.8)

--- a/config/solr.yml
+++ b/config/solr.yml
@@ -1,7 +1,7 @@
 # This is a sample config file that points to a solr server for each environment
 development:
   url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:8983/solr/nurax-pg-solr-dev" %>
-test: &test
+test:
   url: <%= ENV['TEST_SOLR_URL'] ||ENV['SOLR_URL'] || "http://127.0.0.1:#{ENV.fetch('SOLR_TEST_PORT', 8983)}/solr/nurax-pg-test" %>
 production:
   url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:8983/solr/nurax-pg" %>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -154,7 +154,7 @@ services:
     command:
       - sh
       - "-c"
-      - "solr-precreate dlp-selfdeposit /opt/solr/server/configsets/hyraxconf; solr-precreate dlp-selfdeposit-test /opt/solr/server/configsets/hyraxconf"
+      - "precreate-core dlp-selfdeposit-test /opt/solr/server/configsets/hyraxconf; solr-precreate dlp-selfdeposit /opt/solr/server/configsets/hyraxconf"
     volumes:
       - solr:/var/solr/data:cached
       - ./solr/conf:/opt/solr/server/configsets/hyraxconf

--- a/spec/models/bulkrax/csv_entry_spec.rb
+++ b/spec/models/bulkrax/csv_entry_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe Bulkrax::CsvEntry, :clean, type: :model do
+RSpec.describe Bulkrax::CsvEntry, type: :model do
   describe '#build_metadata with our added parsing logic' do
     let(:path) { File.expand_path('../../fixtures/csv/parsing_test.csv', __dir__) }
     let(:importer) do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -3,8 +3,8 @@
 require 'spec_helper'
 require 'devise'
 require 'devise_saml_authenticatable'
-ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../config/environment', __dir__)
+
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'rspec/rails'
@@ -35,12 +35,6 @@ end
 
 Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
 
-begin
-  ActiveRecord::Migration.maintain_test_schema!
-rescue ActiveRecord::PendingMigrationError => e
-  puts e.to_s.strip
-  exit 1
-end
 RSpec.configure do |config|
   config.fixture_path = Rails.root.join('spec', 'fixtures').to_s
   config.use_transactional_fixtures = true

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -35,7 +35,6 @@ end
 
 Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
 
-
 begin
   ActiveRecord::Migration.maintain_test_schema!
 rescue ActiveRecord::PendingMigrationError => e

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -35,6 +35,14 @@ end
 
 Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
 
+
+begin
+  ActiveRecord::Migration.maintain_test_schema!
+rescue ActiveRecord::PendingMigrationError => e
+  puts e.to_s.strip
+  exit 1
+end
+
 RSpec.configure do |config|
   config.fixture_path = Rails.root.join('spec', 'fixtures').to_s
   config.use_transactional_fixtures = true

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,12 +10,14 @@ require 'database_cleaner'
 ENV['RAILS_ENV'] = 'test'
 ENV['DATABASE_URL'] = ENV['DATABASE_TEST_URL'] if ENV['DATABASE_TEST_URL']
 
-db_config = ActiveRecord::Base.configurations[ENV['RAILS_ENV']]
-ActiveRecord::Tasks::DatabaseTasks.create(db_config)
-ActiveRecord::Migrator.migrations_paths = [Pathname.new(ENV['RAILS_ROOT']).join('db', 'migrate').to_s]
-ActiveRecord::Tasks::DatabaseTasks.migrate
-ActiveRecord::Base.descendants.each(&:reset_column_information)
-ActiveRecord::Migration.maintain_test_schema!
+unless ENV['CI']
+  db_config = ActiveRecord::Base.configurations[ENV['RAILS_ENV']]
+  ActiveRecord::Tasks::DatabaseTasks.create(db_config)
+  ActiveRecord::Migrator.migrations_paths = [Pathname.new(ENV['RAILS_ROOT']).join('db', 'migrate').to_s]
+  ActiveRecord::Tasks::DatabaseTasks.migrate
+  ActiveRecord::Base.descendants.each(&:reset_column_information)
+  ActiveRecord::Migration.maintain_test_schema!
+end
 
 Coveralls.wear!('rails')
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,10 +8,11 @@ require 'rspec/active_model/mocks'
 require 'database_cleaner'
 
 ENV['RAILS_ENV'] = 'test'
-ENV['DATABASE_URL'] = ENV['DATABASE_TEST_URL'] if ENV['DATABASE_TEST_URL']
 
 unless ENV['CI']
+  ENV['DATABASE_URL'] = ENV['DATABASE_TEST_URL'] if ENV['DATABASE_TEST_URL']
   db_config = ActiveRecord::Base.configurations[ENV['RAILS_ENV']]
+
   ActiveRecord::Tasks::DatabaseTasks.create(db_config)
   ActiveRecord::Migrator.migrations_paths = [Pathname.new(ENV['RAILS_ROOT']).join('db', 'migrate').to_s]
   ActiveRecord::Tasks::DatabaseTasks.migrate

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,17 @@ require 'hyrax/specs/shared_specs/factories/strategies/valkyrie_resource'
 require 'hyrax/specs/shared_specs/factories/users'
 require 'coveralls'
 require 'rspec/active_model/mocks'
+require 'database_cleaner'
+
+ENV['RAILS_ENV'] = 'test'
+ENV['DATABASE_URL'] = ENV['DATABASE_TEST_URL'] if ENV['DATABASE_TEST_URL']
+
+db_config = ActiveRecord::Base.configurations[ENV['RAILS_ENV']]
+ActiveRecord::Tasks::DatabaseTasks.create(db_config)
+ActiveRecord::Migrator.migrations_paths = [Pathname.new(ENV['RAILS_ROOT']).join('db', 'migrate').to_s]
+ActiveRecord::Tasks::DatabaseTasks.migrate
+ActiveRecord::Base.descendants.each(&:reset_column_information)
+ActiveRecord::Migration.maintain_test_schema!
 
 Coveralls.wear!('rails')
 
@@ -31,11 +42,26 @@ RSpec.configure do |config|
 
   # The following behaviors are copied from Hyrax v5.0.1's spec_helper.rb
   config.before :suite do
+    DatabaseCleaner.clean_with(:truncation)
     User.group_service = TestHydraGroupService.new
   end
 
-  config.after :suite do
+  config.after do
+    DatabaseCleaner.clean
     User.group_service.clear
+  end
+
+  config.before do |example|
+    if example.metadata[:type] == :feature && Capybara.current_driver != :rack_test
+      DatabaseCleaner.strategy = :truncation
+    else
+      DatabaseCleaner.strategy = :transaction
+      DatabaseCleaner.start
+    end
+
+    # using :workflow is preferable to :clean_repo, use the former if possible
+    # It's important that this comes after DatabaseCleaner.start
+    ensure_deposit_available_for(user) if example.metadata[:workflow] && defined?(user)
   end
 
   config.prepend_before(:example, :storage_adapter) do |example|
@@ -50,7 +76,7 @@ RSpec.configure do |config|
     adapter_name = example.metadata[:valkyrie_adapter]
 
     if adapter_name == :wings_adapter
-      skip("Don't test Wings when it is dasabled") if Hyrax.config.disable_wings
+      skip("Don't test Wings when it is disabled") if Hyrax.config.disable_wings
     else
       allow(Hyrax.config).to receive(:disable_wings).and_return(true)
       hide_const("Wings") # disable_wings=true removes the Wings constant


### PR DESCRIPTION
- Gemfile* and spec/spec_helper.rb: adds `DatabaseCleaner` to make PG wipes automatic.
- config/solr.yml: removes weird `&test` addition.
- docker-compose.yml: swaps the creation calls so that both db instances can be created.
- spec/models/bulkrax/csv_entry_spec.rb: removes the unnecessary `clean` request.
- spec/rails_helper.rb: moves the environment assignment to `spec_helper` so that it happens first.
- spec/spec_helper.rb: explicitly defines RSpec environment as `test`, stubs a separate database for the environment, and forces migration before any other action.