### PR TITLE
Reworks PreservationEvents to use it in multiple places.

### DIFF
--- a/lib/preservation_events.rb
+++ b/lib/preservation_events.rb
@@ -29,4 +29,19 @@ module PreservationEvents
 
     event
   end
+
+  def work_creation(event_start:, user_email:)
+    { 'type' => 'Validation', 'start' => event_start, 'outcome' => 'Success', 'details' => 'Submission package validated',
+      'software_version' => 'SelfDeposit v.1', 'user' => user_email }
+  end
+
+  def work_policy(event_start:, visibility:, user_email:)
+    { 'type' => 'Policy Assignment', 'start' => event_start, 'outcome' => 'Success', 'software_version' => 'SelfDeposit v.1',
+      'details' => "Visibility/access controls assigned: #{visibility}", 'user' => user_email }
+  end
+
+  def work_update(event_start:, user_email:)
+    { 'type' => 'Modification', 'start' => event_start, 'outcome' => 'Success', 'details' => 'Object updated',
+      'software_version' => 'SelfDeposit v.1', 'user' => user_email }
+  end
 end

--- a/spec/lib/preservation_events_spec.rb
+++ b/spec/lib/preservation_events_spec.rb
@@ -17,22 +17,64 @@ RSpec.describe PreservationEvents, :clean do
 
     Hyrax.persister.save(resource: work)
   end
-
-  let(:start) { 1.day.ago }
+  start_time = 1.day.ago
   let(:end_time) { 10.minutes.ago }
-  let(:event) do
-    { 'type' => 'Policy Assignment', 'start' => start, 'end' => end_time,
-      'details' => "Visibility/access controls assigned: Emory Network",
-      'software_version' => 'SelfDeposit 1.0', 'user' => 'admin@example.com',
-      'outcome' => 'Success' }
-  end
   let(:saved_event) { create_preservation_event(work, event) }
   let(:queried_work) { Hyrax.query_service.find_by(id: work.id) }
+
+  shared_context 'with a preservation_event hash' do |policy|
+    let(:event) do
+      policy['end'] = end_time
+      policy
+    end
+  end
+
+  shared_examples 'tests expected values of a PreservationEvent' do |method_name, expected_details, expected_type, start|
+    it "contains the expected values (#{method_name})" do
+      expect(saved_event.event_details).to eq(expected_details)
+      expect(saved_event.event_end).to eq(end_time)
+      expect(saved_event.event_start).to eq(start)
+      expect(saved_event.event_type).to eq(expected_type)
+      expect(saved_event.initiating_user).to eq('admin@example.com')
+      expect(saved_event.outcome).to eq('Success')
+      expect(saved_event.software_version).to eq('SelfDeposit v.1')
+    end
+  end
+
+  include_context(
+    'with a preservation_event hash', work_policy(event_start: start_time, visibility: 'Emory Network', user_email: 'admin@example.com')
+  )
 
   context '#create_preservation_event' do
     it 'returns a persisted PreservationEvent' do
       expect(saved_event).to be_a PreservationEvent
       expect(saved_event).to be_persisted
+    end
+
+    include_examples(
+      'tests expected values of a PreservationEvent',
+      'work_policy',
+      'Visibility/access controls assigned: Emory Network',
+      'Policy Assignment',
+      start_time
+    )
+
+    context 'work_creation type of event' do
+      include_context(
+        'with a preservation_event hash', work_creation(event_start: start_time, user_email: 'admin@example.com')
+      )
+
+      include_examples(
+        'tests expected values of a PreservationEvent', 'work_creation', 'Submission package validated', 'Validation', start_time
+      )
+    end
+
+    context 'work_update type of event' do
+      include_context(
+        'with a preservation_event hash', work_update(event_start: start_time, user_email: 'admin@example.com')
+      )
+
+      include_examples('tests expected values of a PreservationEvent', 'work_update', 'Object updated', 'Modification', start_time)
     end
 
     it 'adds PreservationEvent id to work attribute #preservation_event_ids' do


### PR DESCRIPTION
- app/controllers/hyrax/publications_controller.rb: moves the event methods to the module and updates the Pres Events creation method with the named variable convention.
- config/initializers/bulkrax.rb: uses the modified methods where Bulkrax processes works.
- lib/preservation_events.rb: refactors the event creation methods to accept passed arguments.
- spec/lib/preservation_events_spec.rb: updates the testing.