### PR TITLE
Assigns the public FileSet to Representative, Rendering, and Thumbnail.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,6 +21,7 @@ Metrics/AbcSize:
     - app/indexers/self_deposit/indexers/file_set_indexer.rb
     - app/services/hyrax/valkyrie_upload.rb
     - config/initializers/hyrax_edit_permissions_service_override.rb
+    - config/initializers/hyrax_work_uploads_handler_override.rb
 
 Metrics/MethodLength:
   Exclude:


### PR DESCRIPTION
- .rubocop.yml: stops rubocop from analyzing this Hyrax-overridden method.
- config/initializers/hyrax_work_uploads_handler_override.rb: overwrites the `attach` method so that we can locate the public FileSet and put it in the three display variables.