### PR TITLE
Adds full text search capabilities.

### DIFF
--- a/app/assets/javascripts/ocr_search.js.erb
+++ b/app/assets/javascripts/ocr_search.js.erb
@@ -1,0 +1,14 @@
+<%#
+# gem 'newspaper_works', v1.0.2
+# Refer to the gem repository for more details: https://github.com/samvera-labs/newspaper_works
+# Released under license Apache License 2.0: https://github.com/samvera-labs/newspaper_works/blob/main/LICENSE
+# This gem is not yet compatible with Hyrax v3, hence why I am only using the portions relevant to our use case
+# This gem is used for keyword highlighting in search results
+%>
+
+/* toggle the ocr snippets collapse link text */
+$(document).ready(function(){
+  $('.ocr_snippets_expand').click(function() {
+    $(this).text($(this).text() == 'more >>' ? '<< less' : 'more >>');
+  });
+});

--- a/app/assets/stylesheets/hyrax.scss
+++ b/app/assets/stylesheets/hyrax.scss
@@ -23,6 +23,7 @@
 @import "scss/layout";
 @import "scss/header";
 @import "scss/footer";
+@import "scss/search_results";
 
 //responsive last
 @import "scss/responsive";

--- a/app/assets/stylesheets/scss/search_results.scss
+++ b/app/assets/stylesheets/scss/search_results.scss
@@ -1,0 +1,18 @@
+// gem 'newspaper_works', v1.0.2
+// Refer to the gem repository for more details: https://github.com/samvera-labs/newspaper_works
+// Released under license Apache License 2.0: https://github.com/samvera-labs/newspaper_works/blob/main/LICENSE
+// This gem is not yet compatible with Hyrax v3, hence why I am only using the portions relevant to our use case
+// This gem is used for keyword highlighting in search results
+
+$highlight-background-color: rgba(5,166,86,0.36);
+
+#search-results .thumbnail_highlight, #documents .thumbnail_highlight {
+  background-color: $highlight-background-color;
+  z-index: 1000;
+  position: absolute;
+}
+
+.metadata em {
+  background-color: $highlight-background-color;
+  font-weight: bold;
+}

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -78,6 +78,7 @@ class CatalogController < ApplicationController
     config.add_index_field "license_tesi", helper_method: :license_links, label: 'License'
     config.add_index_field Hydra.config.permissions.embargo.release_date, label: "Embargo release date", helper_method: :human_readable_date
     config.add_index_field Hydra.config.permissions.lease.expiration_date, label: "Lease expiration date", helper_method: :human_readable_date
+    config.add_index_field 'all_text_tsimv', highlight: true, helper_method: :render_ocr_snippets
 
     # solr fields to be displayed in the show (single result) view
     #   The ordering of the field names is the order of the display
@@ -127,7 +128,7 @@ class CatalogController < ApplicationController
       all_names = config.show_fields.values.map(&:field).join(" ")
       title_name = "title_tesim"
       field.solr_parameters = {
-        qf: "#{all_names} file_format_tesim all_text_timv",
+        qf: "#{all_names} file_format_tesim all_text_tsimv",
         pf: title_name.to_s
       }
     end

--- a/app/helpers/hyrax_helper.rb
+++ b/app/helpers/hyrax_helper.rb
@@ -3,4 +3,5 @@ module HyraxHelper
   include ::BlacklightHelper
   include Hyrax::BlacklightOverride
   include Hyrax::HyraxHelperBehavior
+  include NewspaperWorks::NewspaperWorksHelperBehavior
 end

--- a/app/helpers/newspaper_works/newspaper_works_helper_behavior.rb
+++ b/app/helpers/newspaper_works/newspaper_works_helper_behavior.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+# gem 'newspaper_works', v1.0.2
+# Refer to the gem repository for more details: https://github.com/samvera-labs/newspaper_works
+# Released under license Apache License 2.0: https://github.com/samvera-labs/newspaper_works/blob/main/LICENSE
+# This gem is not yet compatible with Hyrax v3, hence why I am only using the portions relevant to our use case
+# This gem is used for keyword highlighting in search results
+
+module NewspaperWorks
+  module NewspaperWorksHelperBehavior
+    ##
+    # print the ocr snippets. if more than one, separate with <br/>
+    #
+    # @param options [Hash] options hash provided by Blacklight
+    # @return [String] snippets HTML to be rendered
+    # rubocop:disable Rails/OutputSafety
+    def render_ocr_snippets(options = {})
+      snippets = options[:value]
+      snippets_content = [tag.div("... #{snippets.first} ...".html_safe,
+                                      class: 'ocr_snippet first_snippet')]
+      if snippets.length > 1
+        snippets_content << render(partial: 'catalog/snippets_more',
+                                   locals: { snippets: snippets.drop(1), options: })
+      end
+      snippets_content.join("\n").html_safe
+    end
+    # rubocop:enable Rails/OutputSafety
+  end
+end

--- a/app/indexers/publication_indexer.rb
+++ b/app/indexers/publication_indexer.rb
@@ -13,6 +13,7 @@ class PublicationIndexer < Hyrax::Indexers::PcdmObjectIndexer(Publication)
       index_document[:preservation_events_tesim] = resource&.preservation_events&.map(&:preservation_event_terms)
       index_document[:preservation_workflow_terms_tesim] = preservation_workflow_terms
       index_document[:alternate_ids_ssim] = find_alternate_ids
+      index_document[:all_text_tsimv] = resource&.primary_file_set&.extracted_text_content
     end
   end
 

--- a/app/models/file_set.rb
+++ b/app/models/file_set.rb
@@ -9,4 +9,8 @@ class FileSet < Hyrax::FileSet
 
   include Hyrax::Schema(:emory_file_set_metadata)
   include PreservationEventModelMethods
+
+  def extracted_text_content
+    extracted_text&.file&.read
+  end
 end

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -30,4 +30,12 @@ class Publication < Hyrax::Work
       []
     end
   end
+
+  def file_sets
+    Hyrax.custom_queries.find_child_file_sets(resource: self)
+  end
+
+  def primary_file_set
+    file_sets&.find { |fs| fs.file_set_use == 'Primary Content' }
+  end
 end

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -5,6 +5,8 @@ class SearchBuilder < Blacklight::SearchBuilder
   include Hydra::AccessControlsEnforcement
   include Hyrax::SearchFilters
 
+  self.default_processor_chain += [:highlight_search_params]
+
   ##
   # @example Adding a new step to the processor chain
   #   self.default_processor_chain += [:add_custom_data_to_query]
@@ -12,4 +14,12 @@ class SearchBuilder < Blacklight::SearchBuilder
   #   def add_custom_data_to_query(solr_parameters)
   #     solr_parameters[:custom] = blacklight_params[:user_value]
   #   end
+
+  def highlight_search_params(solr_parameters = {})
+    return unless solr_parameters[:q] || solr_parameters[:all_fields]
+    solr_parameters[:hl] = true
+    solr_parameters[:'hl.fl'] = 'all_text_tsimv'
+    solr_parameters[:'hl.fragsize'] = 100
+    solr_parameters[:'hl.snippets'] = 5
+  end
 end

--- a/app/views/catalog/_index_list_default.html.erb
+++ b/app/views/catalog/_index_list_default.html.erb
@@ -13,15 +13,15 @@
   </div>
 </div>
 <% if document.collection? %>
-<% collection_presenter = Hyrax::CollectionPresenter.new(document, current_ability) %>
-<div class="col-md-9 col-lg-3">
-  <div class="collection-counts-wrapper">
-    <div class="collection-counts-item">
-      <span><%= collection_presenter.total_viewable_collections %></span>Collections
-    </div>
-    <div class="collection-counts-item">
-      <span><%= collection_presenter.total_viewable_works %></span>Works
+  <% collection_presenter = Hyrax::CollectionPresenter.new(document, current_ability) %>
+  <div class="col-md-9 col-lg-3">
+    <div class="collection-counts-wrapper">
+      <div class="collection-counts-item">
+        <span><%= collection_presenter.total_viewable_collections %></span>Collections
+      </div>
+      <div class="collection-counts-item">
+        <span><%= collection_presenter.total_viewable_works %></span>Works
+      </div>
     </div>
   </div>
-</div>
 <% end %>

--- a/app/views/catalog/_snippets_more.html.erb
+++ b/app/views/catalog/_snippets_more.html.erb
@@ -1,0 +1,24 @@
+<%#
+# gem 'newspaper_works', v1.0.2
+# Refer to the gem repository for more details: https://github.com/samvera-labs/newspaper_works
+# Released under license Apache License 2.0: https://github.com/samvera-labs/newspaper_works/blob/main/LICENSE
+# This gem is not yet compatible with Hyrax v3, hence why I am only using the portions relevant to our use case
+# This gem is used for keyword highlighting in search results
+%>
+
+<%# additional ocr snippets, with a Bootstrap collapse toggle control %>
+<% document_id = options[:document].id %>
+<div class="collapse ocr_snippet" id="<%= "snippet_collapse_#{document_id}" %>">
+  <% snippets.each do |snippet| %>
+    <%= content_tag('div',
+                    "... #{snippet} ...".html_safe,
+                    class: 'ocr_snippet') %>
+  <% end %>
+</div>
+<%= link_to('more >>',
+            "#snippet_collapse_#{document_id}",
+            data: {toggle: 'collapse'},
+            'aria-expanded' => 'false',
+            'aria-controls' => "#snippet_collapse_#{document_id}",
+            class: 'ocr_snippets_expand js-controls')
+%>

--- a/config/initializers/blacklight_blacklight_helper_behavior_override.rb
+++ b/config/initializers/blacklight_blacklight_helper_behavior_override.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+# [Blacklight-overwrite-v7.37.0]
+#   - should_render_index_field?: need to block `all_text_tsimv` when it returns values with no string provided for query.
+
+Rails.application.config.to_prepare do
+  Blacklight::BlacklightHelperBehavior.module_eval do
+    # @!group Document helpers
+    ##
+    # Determine whether to render a given field in the index view.
+    #
+    # @deprecated
+    # @param [SolrDocument] document
+    # @param [Blacklight::Configuration::Field] field_config
+    # @return [Boolean]
+    def should_render_index_field?(document, field_config)
+      Deprecation.warn self, "should_render_index_field? is deprecated and will be removed in Blacklight 8. Use IndexPresenter#render_field? instead."
+
+      return false if field_config.field == 'all_text_tsimv' && (request.url =~ /q=\S/).nil?
+      should_render_field?(field_config, document) && document_has_value?(document, field_config)
+    end
+  end
+end

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -13,6 +13,7 @@ en:
           publisher_sim: Publisher
           subject_sim: Subject
         index:
+          all_text_tsimv: Keyword matches
           based_near_tesim: Location
           contributor_tesim: Contributor
           creator_tesim: Authors


### PR DESCRIPTION
- app/assets/javascripts/ocr_search.js.erb: imports code for hiding/revealing additional snippets.
- app/assets/stylesheets/*: adds styling from Curate's codebase.
- app/controllers/catalog_controller.rb: adds the all text solr field to both the `All Fields` search option and the index page.
- app/helpers/*: copies and updates the helper code from Curate.
- app/indexers/publication_indexer.rb: uses the newly formed class models to index the primary fileset's extracted text.
- app/models/file_set.rb: provides convenience method that returns a fileset's extracted_text.
- app/models/publication.rb: makes the class aware of its child filesets and, particularly, the primary content FileSet.
- app/models/search_builder.rb: carries over the search logic to our default processor chain.
- app/views/catalog/_index_list_default.html.erb: a slight refactor.
- app/views/catalog/_snippets_more.html.erb: brought over from Curate to process the additional snippets correctly.
- config/initializers/blacklight_blacklight_helper_behavior_override.rb: overridden because this newer version of Hyrax delivers the full value of the new solr field without highlighting when an empty search is performed.
- config/locales/hyrax.en.yml: adds title to field values in index page.