### PR TITLE
Updating to Amazon Linux 2023 Shibboleth repository.

### DIFF
--- a/ansible/files/shib.repo
+++ b/ansible/files/shib.repo
@@ -1,10 +1,9 @@
 [shibboleth]
-name=Shibboleth (amazonlinux2)
+name=Shibboleth (amazonlinux2023)
 # Please report any problems to https://shibboleth.atlassian.net/jira
 type=rpm-md
-mirrorlist=https://shibboleth.net/cgi-bin/mirrorlist.cgi/amazonlinux2
+mirrorlist=https://shibboleth.net/cgi-bin/mirrorlist.cgi/amazonlinux2023
 gpgcheck=1
 gpgkey=https://shibboleth.net/downloads/service-provider/RPMS/repomd.xml.key
         https://shibboleth.net/downloads/service-provider/RPMS/cantor.repomd.xml.key
 enabled=1
-


### PR DESCRIPTION
Changing Shibboleth repo from Amazon Linux 2 to Amazon Linux 2023.