### PR TITLE
Corrects the regex preventing the full text from displaying in Full Text matches field.

### DIFF
--- a/config/initializers/blacklight_blacklight_helper_behavior_override.rb
+++ b/config/initializers/blacklight_blacklight_helper_behavior_override.rb
@@ -15,7 +15,7 @@ Rails.application.config.to_prepare do
     def should_render_index_field?(document, field_config)
       Deprecation.warn self, "should_render_index_field? is deprecated and will be removed in Blacklight 8. Use IndexPresenter#render_field? instead."
 
-      return false if field_config.field == 'all_text_tsimv' && (request.url =~ /q=\S/).nil?
+      return false if field_config.field == 'all_text_tsimv' && (request.url =~ /q=\w/).nil?
       should_render_field?(field_config, document) && document_has_value?(document, field_config)
     end
   end


### PR DESCRIPTION
NOTE: the original regex was testing for the presence of a search term in the url, but this didn't work as intended when the path was like this: https://oe24-test.libraries.emory.edu/catalog?locale=en&page=2&q=&search_field=all_fields. This corrects that behavior.