### PR TITLE
Report each remediated id.

### DIFF
--- a/app/services/self_deposit/custom_queries/find_all_object_ids_with_alternate_ids_present.rb
+++ b/app/services/self_deposit/custom_queries/find_all_object_ids_with_alternate_ids_present.rb
@@ -30,8 +30,10 @@ module SelfDeposit
       def each
         docs = Valkyrie::Persistence::Solr::Queries::DefaultPaginator.new
         while docs.has_next?
-          docs = @connection.paginate(docs.next_page, docs.per_page, "select", params: { q: query, fq: filter_query })["response"]["docs"]
-          docs.each { |doc| yield doc['id'] }
+          docs = @connection.paginate(
+                   docs.next_page, docs.per_page, "select", params: { q: query, fq: filter_query, fl: fields_selection }
+                 )["response"]["docs"]
+          docs.each { |doc| yield doc }
         end
       end
 
@@ -43,6 +45,10 @@ module SelfDeposit
 
       def filter_query
         "has_model_ssim:Publication || has_model_ssim:FileSet || has_model_ssim:CollectionResource"
+      end
+
+      def fields_selection
+        "alternate_ids_ssim, id"
       end
     end
   end

--- a/spec/services/self_deposit/custom_queries/find_all_object_ids_with_alternate_ids_present_spec.rb
+++ b/spec/services/self_deposit/custom_queries/find_all_object_ids_with_alternate_ids_present_spec.rb
@@ -22,7 +22,9 @@ RSpec.describe SelfDeposit::CustomQueries::FindAllObjectIdsWithAlternateIdsPrese
         publication
 
         expect(query_handler.find_all_object_ids_with_alternate_ids_present).to be_a(Enumerator)
-        expect(query_handler.find_all_object_ids_with_alternate_ids_present.to_a).to eq([publication.id])
+        expect(query_handler.find_all_object_ids_with_alternate_ids_present.to_a.first).to eq(
+          { "id" => publication.id, "alternate_ids_ssim" => ["145djjdjd-emory"] }
+        )
       end
     end
   end


### PR DESCRIPTION
- app/services/self_deposit/custom_queries/find_all_object_ids_with_alternate_ids_present.rb: because of errors tied to pulling alternate_ids from objects, we are returning the values from the Solr documents instead.
- app/services/self_deposit/valkyrie_object_remediation_service.rb: 
  - skips pulling the alternate_ids from the Valkyrie object and uses the value from the query.
  - adds Rails logging so that we can track progress and errors for debugging.
- spec/services/self_deposit/custom_queries/find_all_object_ids_with_alternate_ids_present_spec.rb: updates test expectations.