### PR TITLE
Replaces the display of document's full text with a warning message.

### DIFF
--- a/app/helpers/newspaper_works/newspaper_works_helper_behavior.rb
+++ b/app/helpers/newspaper_works/newspaper_works_helper_behavior.rb
@@ -12,17 +12,33 @@ module NewspaperWorks
     #
     # @param options [Hash] options hash provided by Blacklight
     # @return [String] snippets HTML to be rendered
-    # rubocop:disable Rails/OutputSafety
     def render_ocr_snippets(options = {})
       snippets = options[:value]
-      snippets_content = [tag.div("... #{snippets.first} ...".html_safe,
+      snippets_content = [tag.div(safe_join(['... ', snippets.first, ' ...']),
                                       class: 'ocr_snippet first_snippet')]
       if snippets.length > 1
         snippets_content << render(partial: 'catalog/snippets_more',
                                    locals: { snippets: snippets.drop(1), options: })
       end
-      snippets_content.join("\n").html_safe
+
+      full_text_no_emphasis_text(snippets) ? multiple_match_text(id: options[:document][:id]) : safe_join(snippets_content)
     end
-    # rubocop:enable Rails/OutputSafety
+
+    private
+
+    def full_text_no_emphasis_text(snippets_array)
+      snippets_array.length == 1 && !snippets_array.first.include?('<em>')
+    end
+
+    def multiple_match_text(id:)
+      tag.div(
+        safe_join(['Multiple matches found. Please ', publication_show_page_link(id:), ' for more search options.']),
+        class: 'ocr_snippet first_snippet'
+      )
+    end
+
+    def publication_show_page_link(id:)
+      link_to('view the publication file', hyrax_publication_path(id))
+    end
   end
 end

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -21,6 +21,5 @@ class SearchBuilder < Blacklight::SearchBuilder
     solr_parameters[:'hl.fl'] = 'all_text_tsimv'
     solr_parameters[:'hl.fragsize'] = 100
     solr_parameters[:'hl.snippets'] = 5
-    solr_parameters[:'hl.method'] = 'fastVector'
   end
 end


### PR DESCRIPTION
- app/helpers/newspaper_works/newspaper_works_helper_behavior.rb: provides a warning message in place of the document's full text when the text has no highlighting.
- app/models/search_builder.rb: switches back to `Unified` default.