### PR TITLE
remove space between header and hero banner for the homepage.

### DIFF
--- a/app/assets/stylesheets/scss/layout.scss
+++ b/app/assets/stylesheets/scss/layout.scss
@@ -138,6 +138,7 @@ a {
 }
 
 .dlp-hero {
+  margin-top: -2rem; //remove space between header and hero for the homepage.
   background-image: image_url("skyline.jpg");
   background-size: cover;
   background-repeat: no-repeat;


### PR DESCRIPTION
tiny edit due to creating more space between pages.

before: 
![image](https://github.com/user-attachments/assets/6bf71266-029f-4f28-8c7b-1776ef29843a)
after: 
![image](https://github.com/user-attachments/assets/8ef0a399-159d-4955-9ea6-d82cfd51617e)
