### PR TITLE
Reconfigures Collection show pages values.

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -52,4 +52,54 @@ class SolrDocument
   def title_label_or_filename
     title&.first&.presence || label&.first&.presence || self['original_filename_ssi']
   end
+
+  def emory_persistent_id
+    self['emory_persistent_id_ssi']
+  end
+
+  def holding_repository
+    self['holding_repository_ssi']
+  end
+
+  def institution
+    self['institution_ssi']
+  end
+
+  def contact_information
+    self['contact_information_ssi']
+  end
+
+  def subject_geo
+    self['subject_geo_ssim']
+  end
+
+  def subject_names
+    self['subject_names_ssim']
+  end
+
+  def notes
+    self['notes_ssim']
+  end
+
+  def emory_ark
+    self['emory_ark_tesim']
+  end
+
+  # rubocop:disable Naming/MethodName
+  def system_of_record_ID
+    self['system_of_record_ID_ssi']
+  end
+  # rubocop:enable Naming/MethodName
+
+  def staff_notes
+    self['staff_notes_tesim']
+  end
+
+  def internal_rights_note
+    self['internal_rights_note_tesi']
+  end
+
+  def administrative_unit
+    self['administrative_unit_ssi']
+  end
 end

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -48,13 +48,13 @@
 <%= custom_facet_renderer.new('research_categories', 
       presenter.solr_document['research_categories_ssim'], {search_field: 'research_categories_ssim'}).render_dl_row %>
 <% if current_user.try(:admin?) %>
-  <%= generic_renderer.new(:emory_ark, presenter.solr_document['emory_ark_tesim'], {}).render_dl_row  %>
-  <%= generic_renderer.new(:internal_rights_note, presenter.solr_document['internal_rights_note_tesi'], {}).render_dl_row  %>
-  <%= generic_renderer.new(:staff_notes, presenter.solr_document['staff_notes_tesim'], {}).render_dl_row  %>
-  <%= facet_renderer.new(:system_of_record_ID, presenter.solr_document['system_of_record_ID_ssi'], {}).render_dl_row  %>
+  <%= generic_renderer.new(:emory_ark, presenter.solr_document.emory_ark, {}).render_dl_row  %>
+  <%= generic_renderer.new(:internal_rights_note, presenter.solr_document.internal_rights_note, {}).render_dl_row  %>
+  <%= generic_renderer.new(:staff_notes, presenter.solr_document.staff_notes, {}).render_dl_row  %>
+  <%= facet_renderer.new(:system_of_record_ID, presenter.solr_document.system_of_record_ID, {}).render_dl_row  %>
   <%= ::Hyrax::Renderers::ExternalLinkAttributeRenderer.new(:emory_content_type, content_type_term, {}).render_dl_row  %>
-  <%= facet_renderer.new(:holding_repository, presenter.solr_document['holding_repository_ssi'], {}).render_dl_row  %>
-  <%= facet_renderer.new(:institution, presenter.solr_document['institution_ssi'], {}).render_dl_row  %>
+  <%= facet_renderer.new(:holding_repository, presenter.solr_document.holding_repository, {}).render_dl_row  %>
+  <%= facet_renderer.new(:institution, presenter.solr_document.institution, {}).render_dl_row  %>
   <%= facet_renderer.new(:data_classification, presenter.solr_document['data_classification_ssi'], {}).render_dl_row  %>
   <%= generic_renderer.new(:deduplication_key, presenter.solr_document['deduplication_key_tesi'], {}).render_dl_row  %>
 <% end %>

--- a/app/views/hyrax/base/_purl.html.erb
+++ b/app/views/hyrax/base/_purl.html.erb
@@ -1,8 +1,8 @@
 <dt>Persistent URL</dt>
 <dd>
   <ul class="tabular">
-    <% if presenter.solr_document['emory_persistent_id_ssi'].present? %>
-        <% url = "#{request.base_url}/purl/#{presenter.solr_document['emory_persistent_id_ssi']}" %>
+    <% if presenter.solr_document.emory_persistent_id.present? %>
+        <% url = "#{request.base_url}/purl/#{presenter.solr_document.emory_persistent_id}" %>
         <li><a href="<%= url %>"><%= url %></a></li>
     <% else %>
         <li>No alternate ID available</li>

--- a/app/views/hyrax/collections/_show_descriptions.html.erb
+++ b/app/views/hyrax/collections/_show_descriptions.html.erb
@@ -4,8 +4,8 @@
   <div class='metadata-line'>
     <div class='col-xs-12 col-sm-4'><dt >Persistent URL</dt></div>
     <div class='col-xs-12 col-sm-8'><dd>
-    <% if @presenter.solr_document['emory_persistent_id_ssi'].present? %>
-        <% url = "#{request.base_url}/purl/#{@presenter.solr_document['emory_persistent_id_ssi']}" %>
+    <% if @presenter.emory_persistent_id.present? %>
+        <% url = "#{request.base_url}/purl/#{@presenter.emory_persistent_id}" %>
         <a href="<%= url %>"><%= url %></a>
     <% else %>
         No alternate ID available
@@ -18,5 +18,14 @@
       <div class='col-xs-12 col-sm-4'><dt><%= collection_metadata_label(@presenter, field_name) %></dt></div>
       <div class='col-xs-12 col-sm-8'><dd><%= collection_metadata_value(@presenter, field_name) %></dd></div>
     </div>
+  <% end %>
+
+  <% if current_user&.admin? %>
+    <% @presenter.admin_terms_with_values.each do |field_name| %>
+      <div class='metadata-line'>
+      <div class='col-xs-12 col-sm-4'><dt><%= collection_metadata_label(@presenter, field_name) %></dt></div>
+      <div class='col-xs-12 col-sm-8'><dd><%= collection_metadata_value(@presenter, field_name) %></dd></div>
+    </div>
+    <% end %>
   <% end %>
 </dl>

--- a/app/views/hyrax/dashboard/collections/_show_descriptions.html.erb
+++ b/app/views/hyrax/dashboard/collections/_show_descriptions.html.erb
@@ -5,8 +5,8 @@
   <div class='metadata-line'>
     <div class='col-xs-12 col-sm-4'><dt >Persistent URL</dt></div>
     <div class='col-xs-12 col-sm-8'><dd>
-    <% if @presenter.solr_document['emory_persistent_id_ssi'].present? %>
-        <% url = "#{request.base_url}/purl/#{@presenter.solr_document['emory_persistent_id_ssi']}" %>
+    <% if @presenter.emory_persistent_id.present? %>
+        <% url = "#{request.base_url}/purl/#{@presenter.emory_persistent_id}" %>
         <a href="<%= url %>"><%= url %></a>
     <% else %>
         No alternate ID available
@@ -20,5 +20,14 @@
       <dt class="col-5 text-right"><%= collection_metadata_label(@presenter, field_name) %></dt>
       <dd class="col-7"><%= collection_metadata_value(@presenter, field_name) %></dd>
     </div>
+  <% end %>
+
+  <% if current_user&.admin? %>
+    <% @presenter.admin_terms_with_values.each do |field_name| %>
+      <div class="row">
+        <dt class="col-5 text-right"><%= collection_metadata_label(@presenter, field_name) %></dt>
+        <dd class="col-7"><%= collection_metadata_value(@presenter, field_name) %></dd>
+      </div>
+    <% end %>
   <% end %>
 </dl>

--- a/config/initializers/hyrax_collection_presenter_override.rb
+++ b/config/initializers/hyrax_collection_presenter_override.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-# [Hyrax-overwrite-v5.0.1] - Adds in our desired collection terms to the fileset show page.
+# [Hyrax-overwrite-v5.0.1] - Adds in our desired collection terms to the show page.
 
 Rails.application.config.to_prepare do
   Hyrax::CollectionPresenter.class_eval do

--- a/config/initializers/hyrax_collection_presenter_override.rb
+++ b/config/initializers/hyrax_collection_presenter_override.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+# [Hyrax-overwrite-v5.0.1] - Adds in our charaterization terms to show on the fileset show page.
+
+Rails.application.config.to_prepare do
+  Hyrax::CollectionPresenter.class_eval do
+    def self.terms
+      [
+        :creator, :emory_persistent_id, :holding_repository, :institution, :contact_information, :keyword,
+        :subject, :subject_geo, :subject_names, :rights_notes, :notes
+      ]
+    end
+
+    delegate(*terms, to: :solr_document)
+
+    def self.admin_terms
+      [:emory_ark, :system_of_record_ID, :staff_notes, :internal_rights_note, :administrative_unit]
+    end
+
+    delegate(*admin_terms, to: :solr_document)
+
+    def admin_terms_with_values
+      self.class.admin_terms.select { |t| self[t].present? }
+    end
+  end
+end

--- a/config/initializers/hyrax_collection_presenter_override.rb
+++ b/config/initializers/hyrax_collection_presenter_override.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-# [Hyrax-overwrite-v5.0.1] - Adds in our charaterization terms to show on the fileset show page.
+# [Hyrax-overwrite-v5.0.1] - Adds in our desired collection terms to the fileset show page.
 
 Rails.application.config.to_prepare do
   Hyrax::CollectionPresenter.class_eval do

--- a/config/metadata/collection_resource.yaml
+++ b/config/metadata/collection_resource.yaml
@@ -29,6 +29,8 @@ attributes:
       primary: true
       multiple: false
     predicate: http://id.loc.gov/vocabulary/relators/cur
+    index_keys:
+      - 'administrative_unit_ssi'
   contact_information:
     type: string
     multiple: false
@@ -36,6 +38,8 @@ attributes:
       primary: true
       multiple: false
     predicate: http://www.rdaregistry.info/Elements/u/#P60490
+    index_keys:
+      - 'contact_information_ssi'
   description:
     type: string
     multiple: true
@@ -52,6 +56,8 @@ attributes:
       primary: false
       multiple: true
     predicate: http://www.w3.org/2004/02/skos/core#note
+    index_keys:
+      - 'notes_ssim'
   subject_geo:
     type: string
     multiple: false

--- a/spec/features/viewing_a_collection_show_page_spec.rb
+++ b/spec/features/viewing_a_collection_show_page_spec.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+require 'rails_helper'
+require 'hyrax/specs/shared_specs/factories/hyrax_collection'
+include Warden::Test::Helpers
+
+RSpec.describe 'viewing a Collection show page', type: :feature do
+  let(:user) { FactoryBot.create(:user) }
+  selector_value_array = [
+    ['.hyc-title', 'A Good Title'],
+    ['.hyc-description', 'A good description.'],
+    ['.col-sm-8 dd', 'Tom Wolfe'],
+    ['.col-sm-8 dd', '12345678-cor'],
+    ['.col-sm-8 dd', 'Emory University. Library'],
+    ['.col-sm-8 dd', 'Emory University'],
+    ['.col-sm-8 dd', '4075555555'],
+    ['.col-sm-8 dd', 'book'],
+    ['.col-sm-8 dd', 'Southern States'],
+    ['.col-sm-8 dd', 'Atlanta, Georgia, USA'],
+    ['.col-sm-8 dd', 'Radley, Boo'],
+    ['.col-sm-8 dd', 'A note about rights.'],
+    ['.col-sm-8 dd', 'A gernal note.']
+  ]
+
+  admin_selector_value_array = [
+    ['.col-sm-8 dd', 'doi:123456'],
+    ['.col-sm-8 dd', '12345789'],
+    ['.col-sm-8 dd', 'A note from a staff member.'],
+    ['.col-sm-8 dd', 'An internal note about rights.'],
+    ['.col-sm-8 dd', 'Faculty']
+  ]
+
+  dashboard_selector_value_array = [
+    ['.collection-title', 'A Good Title'],
+    ['.collection-description-wrapper section', 'A good description.'],
+    ['.row dd.col-7', 'Tom Wolfe'],
+    ['.row dd.col-7', '12345678-cor'],
+    ['.row dd.col-7', 'Emory University. Library'],
+    ['.row dd.col-7', 'Emory University'],
+    ['.row dd.col-7', '4075555555'],
+    ['.row dd.col-7', 'book'],
+    ['.row dd.col-7', 'Southern States'],
+    ['.row dd.col-7', 'Atlanta, Georgia, USA'],
+    ['.row dd.col-7', 'Radley, Boo'],
+    ['.row dd.col-7', 'A note about rights.'],
+    ['.row dd.col-7', 'A gernal note.']
+  ]
+
+  dashboard_admin_selector_value_array = [
+    ['.row dd.col-7', 'doi:123456'],
+    ['.row dd.col-7', '12345789'],
+    ['.row dd.col-7', 'A note from a staff member.'],
+    ['.row dd.col-7', 'An internal note about rights.'],
+    ['.row dd.col-7', 'Faculty']
+  ]
+
+  shared_examples 'checks for expected values' do |user_type, test_array|
+    it "contains the expected values when #{user_type} user" do
+      test_array.each do |selector, value|
+        expect(page).to have_selector(selector, text: value)
+      end
+    end
+  end
+
+  shared_examples 'checks for lack of expected values' do |user_type, test_array|
+    it "contains the expected values when #{user_type} user" do
+      test_array.each do |selector, value|
+        expect(page).not_to have_selector(selector, text: value)
+      end
+    end
+  end
+
+  let(:collection) do
+    FactoryBot.valkyrie_create(
+      :hyrax_collection,
+      :public,
+      title: ['A Good Title'],
+      description: 'A good description.',
+      creator: ['Tom Wolfe'],
+      emory_persistent_id: '12345678-cor',
+      holding_repository: 'Emory University. Library',
+      institution: 'Emory University',
+      contact_information: '4075555555',
+      keyword: ['book', 'fiction'],
+      subject: ['Southern States'],
+      subject_geo: ['Atlanta, Georgia, USA'],
+      subject_names: ['Radley, Boo'],
+      rights_notes: ['A note about rights.'],
+      notes: ['A gernal note.'],
+      emory_ark: ['doi:123456'],
+      system_of_record_ID: '12345789',
+      staff_notes: ['A note from a staff member.'],
+      internal_rights_note: 'An internal note about rights.',
+      administrative_unit: 'Faculty'
+    )
+  end
+
+  before do
+    visit "/collections/#{collection.id}"
+  end
+
+  include_examples 'checks for expected values', 'normal', selector_value_array
+  include_examples 'checks for lack of expected values', 'normal', admin_selector_value_array
+
+  context 'when admin logged in' do
+    before do
+      # the below code adds the admin role to user
+      user.roles << Role.find_or_create_by(name: Hyrax.config.admin_user_group_name)
+      user.save
+      login_as user
+      visit "/collections/#{collection.id}"
+    end
+
+    include_examples 'checks for expected values', 'admin', selector_value_array
+    include_examples 'checks for expected values', 'admin', admin_selector_value_array
+  end
+
+  describe 'dashboard collection show page' do
+    before do
+      login_as user
+      visit "/dashboard/collections/#{collection.id}"
+    end
+
+    include_examples 'checks for expected values', 'normal', dashboard_selector_value_array
+    include_examples 'checks for lack of expected values', 'normal', dashboard_admin_selector_value_array
+
+    context 'when admin logged in' do
+      before do
+        # the below code adds the admin role to user
+        user.roles << Role.find_or_create_by(name: Hyrax.config.admin_user_group_name)
+        user.save
+        login_as user
+        visit "/dashboard/collections/#{collection.id}"
+      end
+
+      include_examples 'checks for expected values', 'admin', dashboard_selector_value_array
+      include_examples 'checks for expected values', 'admin', dashboard_admin_selector_value_array
+    end
+  end
+end

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -44,4 +44,52 @@ RSpec.describe ::SolrDocument, type: :model do
                      '\"2024-07-08T15:36:11.455+00:00\",\"event_start\":\"2024-07-07T15:46:11.455+00:00\",\"event_type\":' \
                      '\"Policy Assignment\",\"initiating_user\":\"admin@example.com\",\"outcome\":\"Success\",' \
                      '\"software_version\":\"SelfDeposit 1.0\"}')
+  include_examples('tests for a direct solr index value return',
+                   'emory_persistent_id',
+                   'emory_persistent_id_ssi',
+                   '12345678-cor')
+  include_examples('tests for a direct solr index value return',
+                   'holding_repository',
+                   'holding_repository_ssi',
+                   'Emory University. Libraries')
+  include_examples('tests for a direct solr index value return',
+                   'institution',
+                   'institution_ssi',
+                   'Emory University')
+  include_examples('tests for a direct solr index value return',
+                   'contact_information',
+                   'contact_information_ssi',
+                   '4075555555')
+  include_examples('tests for a direct solr index value return',
+                   'subject_geo',
+                   'subject_geo_ssim',
+                   ['Atlanta, Georgia, USA'])
+  include_examples('tests for a direct solr index value return',
+                   'subject_names',
+                   'subject_names_ssim',
+                   ['Carter, Jimmy'])
+  include_examples('tests for a direct solr index value return',
+                   'notes',
+                   'notes_ssim',
+                   ['A note.'])
+  include_examples('tests for a direct solr index value return',
+                   'emory_ark',
+                   'emory_ark_tesim',
+                   ['doi:123456'])
+  include_examples('tests for a direct solr index value return',
+                   'system_of_record_ID',
+                   'system_of_record_ID_ssi',
+                   '12345678-cor')
+  include_examples('tests for a direct solr index value return',
+                   'staff_notes',
+                   'staff_notes_tesim',
+                   ['A note.'])
+  include_examples('tests for a direct solr index value return',
+                   'internal_rights_note',
+                   'internal_rights_note_tesi',
+                   'A note.')
+  include_examples('tests for a direct solr index value return',
+                   'administrative_unit',
+                   'administrative_unit_ssi',
+                   'Faculty')
 end


### PR DESCRIPTION
- app/models/solr_document.rb: adds `solr_document` methods that the presenter uses to pull values.
- app/views/hyrax/base/_attribute_rows.html.erb, app/views/hyrax/base/_purl.html.erb, app/views/hyrax/collections/_show_descriptions.html.erb, and app/views/hyrax/dashboard/collections/_show_descriptions.html.erb: swaps out hash pulling of values to the `solr_document` methods.
- config/initializers/hyrax_collection_presenter_override.rb: overrides the presenter for our desired terms and admin value separation.
- config/metadata/collection_resource.yaml: indexes missing fields from SolrDocuments.
- spec/*: adds testing of the pages and SolrDocuments.