### PR TITLE
Completes last punchlist items for this sprint.

### DIFF
--- a/app/assets/stylesheets/scss/layout.scss
+++ b/app/assets/stylesheets/scss/layout.scss
@@ -129,8 +129,9 @@ a {
 /**** Home Page ****/
 
 /* alert and/or announcement banner */
-div.alert {
-  margin: -2rem 0 2rem 0;
+body:not(.dashboard) div.alert {
+  margin: -2rem -10rem 2rem -10rem;
+  padding: 0.75rem 5rem
 }
 
 div#announcement_text {
@@ -393,7 +394,7 @@ div#announcement_text {
       }
 
       .dlp-collections-descrip {
-        padding: 0 1rem 1rem
+        padding: 0 1rem 1rem 0;
       }
 
       .dlp-collections-button-wrapper {

--- a/app/assets/stylesheets/scss/responsive.scss
+++ b/app/assets/stylesheets/scss/responsive.scss
@@ -5,6 +5,10 @@
   #search-results dt.data-labels {
     text-align: unset !important;
   }
+  div.home-content.dlp-explore-publications.dlp-fullwidth > div.dlp-explore-publications-wrapper > div.row {
+    margin-right: auto;
+    margin-left: auto;
+  }
 }
 
 /**** Phone/Tablet Screen ****/

--- a/app/assets/stylesheets/scss/responsive.scss
+++ b/app/assets/stylesheets/scss/responsive.scss
@@ -72,11 +72,6 @@
       }
     }
   }
-  /*** homepage ***/
-  div.home-content.dlp-explore-publications.dlp-fullwidth > div.dlp-explore-publications-wrapper > div.row {
-    margin-right: auto;
-    margin-left: auto;
-  }
 
   /**** Footer ****/
   #emory-as-footer footer {
@@ -116,8 +111,12 @@
   .dlp-featured-wrapper {
     padding-bottom: 1rem;
   }
+  div.home-content.dlp-explore-publications.dlp-fullwidth > div.dlp-explore-publications-wrapper > div.row {
+    margin-right: auto;
+    margin-left: auto;
+  }
   .dlp-explore-collections > .dlp-collections-wrapper {
-    padding: unset;
+    padding: 0;
   }
   .dlp-stat {
     padding-bottom: 20px;

--- a/app/assets/stylesheets/scss/responsive.scss
+++ b/app/assets/stylesheets/scss/responsive.scss
@@ -5,10 +5,6 @@
   #search-results dt.data-labels {
     text-align: unset !important;
   }
-  div.home-content.dlp-explore-publications.dlp-fullwidth > div.dlp-explore-publications-wrapper > div.row {
-    margin-right: auto;
-    margin-left: auto;
-  }
 }
 
 /**** Phone/Tablet Screen ****/
@@ -76,6 +72,11 @@
       }
     }
   }
+  /*** homepage ***/
+  div.home-content.dlp-explore-publications.dlp-fullwidth > div.dlp-explore-publications-wrapper > div.row {
+    margin-right: auto;
+    margin-left: auto;
+  }
 
   /**** Footer ****/
   #emory-as-footer footer {
@@ -115,7 +116,9 @@
   .dlp-featured-wrapper {
     padding-bottom: 1rem;
   }
-
+  .dlp-explore-collections > .dlp-collections-wrapper {
+    padding: unset;
+  }
   .dlp-stat {
     padding-bottom: 20px;
   }


### PR DESCRIPTION
- fixes 48, makes any alert message full width on the homepage
- on the collection description, makes the heading flush with the text
- for smallest screens, gets rid of the extra margin on the .row that was making a side gap