### PR TITLE
Updates the RIS delivery logic.

### DIFF
--- a/app/models/concerns/self_deposit/ris_behavior.rb
+++ b/app/models/concerns/self_deposit/ris_behavior.rb
@@ -10,6 +10,7 @@ module SelfDeposit::RisBehavior
     'Presentation': 'GEN',
     'Report': 'REPORT'
   }.freeze
+  URL_REGEX = /\A(http|https):\/\/[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/.*)?\z/ix
 
   def export_as_ris(base_url)
     ris_format = ris_format_template
@@ -36,7 +37,7 @@ module SelfDeposit::RisBehavior
   end
 
   def process_doi_field(ris_key:, value:, ret_text:)
-    dois = value.select { |v| v.include? "doi:" }
+    dois = value.select { |v| v.include?('doi.org') && v.match?(URL_REGEX) }
     dois.each { |doi| assign_unaltered_value_to_ret_txt(ret_text:, ris_key:, value: doi) } if dois.present?
   end
 
@@ -88,7 +89,7 @@ module SelfDeposit::RisBehavior
       process_field_with_added_genre_logic(ret_text:, ris_key:, value:, tests_pass: ["Article", "Conference Paper"].include?(genre))
     end
     if this_field_is_present?(ris_key:, expected_key: [:SP, :EP], value:)
-      process_field_with_added_genre_logic(ret_text:, ris_key:, value:, tests_pass: ["Article", "Book Chapter"].include?(genre))
+      process_field_with_added_genre_logic(ret_text:, ris_key:, value:, tests_pass: ["Article", "Book Chapter", "Conference Paper"].include?(genre))
     end
     process_l2_fields(ret_text:, ris_key:, value:, base_url:) if this_field_is_present?(ris_key:, expected_key: :L2, value:)
   end

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe ::SolrDocument, type: :model do
         'language_tesim': ['English'],
         'date_issued_year_tesi': '1910',
         'publisher_tesim': ['Simon & Schuster'],
-        'final_published_versions_tesim': ['doi:123456'],
+        'final_published_versions_tesim': ['http://dx.doi.org/10.1186/1742-4690-9-S2-P36'],
         'parent_title_tesi': 'Parent Title',
         'conference_name_tesi': 'Samvera 2025',
         'volume_tesi': '10',
@@ -99,8 +99,8 @@ RSpec.describe ::SolrDocument, type: :model do
     describe 'with a genre of Conference Paper' do
       subject(:document) { described_class.new(attributes.merge('content_genre_ssi': 'Conference Paper')) }
 
-      it('contains the right fields') { ris_right_test(right_fields: ['TY', 'TI', 'AU', 'LA', 'PY', 'PB', 'DO', 'T2', 'VL', 'IS', 'CY', 'L2'], expected_ty_field: 'CONF') }
-      it('does not contain the wrong fields') { ris_wrong_test(wrong_fields: ['BT', 'JO', 'SP', 'EP']) }
+      it('contains the right fields') { ris_right_test(right_fields: ['TY', 'TI', 'AU', 'LA', 'PY', 'PB', 'DO', 'T2', 'VL', 'IS', 'CY', 'L2', 'SP', 'EP'], expected_ty_field: 'CONF') }
+      it('does not contain the wrong fields') { ris_wrong_test(wrong_fields: ['BT', 'JO']) }
 
       context 'empty fields' do
         subject(:document) { described_class.new(attributes.merge('content_genre_ssi': 'Conference Paper', 'publisher_tesim': "", 'final_published_versions_tesim': "")) }


### PR DESCRIPTION
- app/models/concerns/self_deposit/ris_behavior.rb:
  - changes `DO` field delivery logic to check for valid URL and the existence of the `doi.org` substring.
  - expands start and end page delivery to include `Conference Paper`.
- spec/models/solr_document_spec.rb: updates the testing to reflect the new logic.