### PR TITLE
Makes pulling of AWS secret deployment-only.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,7 @@ ARG BUNDLE_WITHOUT=
 ONBUILD COPY --chown=1001:101 $APP_PATH /app
 ONBUILD RUN bundle install --jobs "$(nproc)"
 ONBUILD RUN yarn
-ONBUILD RUN RAILS_ENV=production SECRET_KEY_BASE=dummy DB_ADAPTER=nulldb DATABASE_URL='postgresql://fake' bundle exec rake assets:precompile
+ONBUILD RUN RAILS_ENV=production IN_DOCKER=true SECRET_KEY_BASE=dummy DB_ADAPTER=nulldb DATABASE_URL='postgresql://fake' bundle exec rake assets:precompile
 
 
 FROM hyrax-base AS hyrax-worker-base
@@ -94,5 +94,5 @@ ARG BUNDLE_WITHOUT=
 
 COPY --chown=1001:101 $APP_PATH /app
 RUN bundle install --jobs "$(nproc)"
-RUN RAILS_ENV=production SECRET_KEY_BASE=dummy DB_ADAPTER=nulldb DATABASE_URL='postgresql://fake' bundle exec rake assets:precompile
+RUN RAILS_ENV=production IN_DOCKER=true SECRET_KEY_BASE=dummy DB_ADAPTER=nulldb DATABASE_URL='postgresql://fake' bundle exec rake assets:precompile
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -126,7 +126,7 @@ Rails.application.configure do
                        else
                          'sp_cert'
                        end
-  config.private_key = fetch_secret
+  config.private_key = ENV['DB_ADAPTER'] == 'nulldb' ? 'dummy' : fetch_secret
   config.attribute_statements = {
     net_id: ["urn:oid:0.9.2342.19200300.100.1.1"],
     display_name: ["urn:oid:1.3.6.1.4.1.5923.1.1.1.2"],

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -126,7 +126,7 @@ Rails.application.configure do
                        else
                          'sp_cert'
                        end
-  config.private_key = ENV['DB_ADAPTER'] == 'nulldb' ? 'dummy' : fetch_secret
+  config.private_key = ENV['IN_DOCKER'].present? ? 'dummy' : fetch_secret
   config.attribute_statements = {
     net_id: ["urn:oid:0.9.2342.19200300.100.1.1"],
     display_name: ["urn:oid:1.3.6.1.4.1.5923.1.1.1.2"],


### PR DESCRIPTION
@alexBLR and @rotated8 Do you see this fix as problematic? Setting the `ENV["DB_ADAPTER"]` as `nulldb` only occurs in the `Dockerfile`--nowhere else in the code.