### PR TITLE
Adds back CSS that was lost after Collection index restructuring.

### DIFF
--- a/app/assets/stylesheets/scss/dashboard.scss
+++ b/app/assets/stylesheets/scss/dashboard.scss
@@ -90,6 +90,15 @@ body.dashboard {
   div.sort-toggle span.fa-refresh {
     color: $white;
   }
+
+  table.collections-list-table tbody tr td .expanded-details {
+    display: none;
+    padding-top: 10px;
+
+    dd {
+      text-align: left;
+    }
+  }
   /**** end Collections ****/
 
   // works - hide title "Administrative Set"


### PR DESCRIPTION
Directly after page load:
![image](https://github.com/user-attachments/assets/f9aebf0f-41a5-4c8d-a23b-6b666b56e4fc)
