### PR TITLE
Removes the Cite link.

### DIFF
--- a/app/views/hyrax/base/_citations.html.erb
+++ b/app/views/hyrax/base/_citations.html.erb
@@ -1,10 +1,10 @@
 <%# Hyrax v5.0.1 Override: institutes our own layout. Starts line 1. %>
 
-<li class="list-group-item direct_link">
-    <% if Hyrax.config.citations? %>
-      <%= link_to "Cite", hyrax.citations_work_path(presenter), id: 'citations' %>
-    <% end %>
-</li>
+<%# if Hyrax.config.citations? %>
+  <li class="list-group-item direct_link">
+    <%= link_to "Cite", hyrax.citations_work_path(presenter), id: 'citations' %>
+  </li>
+<%# end %>
 
 <li class="list-group-item direct_link>
   <div class="btn-group">

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -55,7 +55,7 @@ Hyrax.config do |config|
 
   # Enables a link to the citations page for a work
   # Default is false
-  config.citations = true
+  # config.citations = true
 
   # Where to store tempfiles, leave blank for the system temp directory (e.g. /tmp)
   # config.temp_file_base = '/home/developer1'


### PR DESCRIPTION
- app/views/hyrax/base/_citations.html.erb: reworks the logic so that the `li` element is only delivered if `citations` is set to true.
- config/initializers/hyrax.rb: comments out citation to hide the link.