### PR TITLE
Removes the Zotero COINS hooks.

### DIFF
--- a/app/views/hyrax/base/_show_actions.html.erb
+++ b/app/views/hyrax/base/_show_actions.html.erb
@@ -45,7 +45,5 @@
   </div>
 </div>
 
-<!-- COinS hook for Zotero -->
-  <span class="Z3988" title="<%= export_as_openurl_ctx_kev(presenter) %>"></span>
 <!-- Render Modals -->
   <%= render 'hyrax/dashboard/collections/form_for_select_collection', user_collections: @user_collections %>

--- a/app/views/hyrax/base/_work_button_row.html.erb
+++ b/app/views/hyrax/base/_work_button_row.html.erb
@@ -1,0 +1,50 @@
+<%# Hyrax v5.0.1 Override: Removes `COinS hook for Zotero` span at bottom of page %>
+
+<div class="row button-row-top-two-column">
+  <div class="col-sm-6">
+    <% if presenter.editor? %>
+      <%= link_to t(".edit"), edit_polymorphic_path([main_app, presenter]), class: 'btn btn-secondary' %>
+      <% if presenter.member_presenters.size > 1 %>
+          <%= link_to t("hyrax.file_manager.link_text"), polymorphic_path([main_app, :file_manager, presenter]), class: 'btn btn-secondary' %>
+      <% end %>
+      <% if presenter.valid_child_concerns.length > 0 %>
+        <div class="btn-group">
+          <button type="button" class="btn btn-secondary dropdown-toggle" type="button" id="dropdown-menu" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            <%= t('.attach_child') %>
+          </button>
+          <ul class="dropdown-menu">
+            <% presenter.valid_child_concerns.each do |concern| %>
+              <li class="dropdown-item">
+                <%= link_to t(".attach", type: concern.human_readable_type), polymorphic_path([main_app, :new, :hyrax, :parent, concern.model_name.singular.to_sym], parent_id: presenter.id) %>
+              </li>
+            <% end %>
+          </ul>
+        </div>
+      <% end %>
+      <%= link_to t(".delete"), [main_app, presenter], class: 'btn btn-danger', data: { confirm: t(".delete_type", type: {presenter.human_readable_type}) }, method: :delete %>
+    <% end %>
+  </div>
+  <div class="col-sm-6 text-right">
+    <% if presenter.show_deposit_for?(collections: @user_collections) %>
+      <input type="checkbox"  style="display:none" name="batch_document_ids[]" id="batch_document_<%= presenter.id %>" value="<%= presenter.id %>" class="batch_document_selector" checked="checked" />
+      <%= button_tag t('hyrax.dashboard.my.action.add_to_collection'),
+                    class: 'btn btn-secondary submits-batches submits-batches-add',
+                    data: { toggle: "modal", target: "#collection-list-container" } %>
+    <% end %>
+    <% if presenter.work_featurable? %>
+      <%= link_to t(".feature"), hyrax.featured_work_path(presenter, format: :json),
+          data: { behavior: 'feature' },
+          class: presenter.display_unfeature_link? ? 'btn btn-secondary collapse' : 'btn btn-secondary' %>
+
+      <%= link_to t(".unfeature"), hyrax.featured_work_path(presenter, format: :json),
+          data: { behavior: 'unfeature' },
+          class: presenter.display_feature_link? ? 'btn btn-secondary collapse' : 'btn btn-secondary' %>
+    <% end %>
+    <% if Hyrax.config.analytics_reporting? %>
+      <%= link_to t(".analytics"), presenter.stats_path, id: 'stats', class: 'btn btn-secondary' %>
+    <% end %>
+  </div>
+</div>
+
+<!-- Render Modals -->
+  <%= render 'hyrax/dashboard/collections/form_for_select_collection', user_collections: @user_collections %>

--- a/spec/features/viewing_a_publication_show_page_spec.rb
+++ b/spec/features/viewing_a_publication_show_page_spec.rb
@@ -52,6 +52,8 @@ RSpec.describe "viewing a publication show page", :clean_repo, :perform_enqueued
     expect(page).to have_link('RIS')
   end
 
+  it('does not contain a COINS hook for Zotero') { expect(page).not_to have_css('span.Z3988') }
+
   context 'when user is admin' do
     # make an admin user for testing preservation events table presence
     before do


### PR DESCRIPTION
- app/views/hyrax/base/*: removes the Zotero COINS hooks because it is the default option, and provides less metadata than the Zotero extension scraping the Google Scholar metadata meta tags.
- spec/features/viewing_a_publication_show_page_spec.rb: checks page to make sure span is missing.