### PR TITLE
Removes the EndNote and Mendeley citation options from SHow page.

### DIFF
--- a/app/views/hyrax/base/_citations.html.erb
+++ b/app/views/hyrax/base/_citations.html.erb
@@ -12,10 +12,8 @@
       <%= "Citation Management Tools" %>
     </div>
     <ul class="dropdown-menu">
-        <li class="dropdown-item"><%= link_to 'RIS', polymorphic_path([main_app, presenter], format: 'ris') %></li>
-        <li class="dropdown-item"><%= link_to t('.endnote'), polymorphic_path([main_app, presenter], format: 'endnote') %></li>
+        <li class="dropdown-item"><%= link_to 'Download Citation (RIS)', polymorphic_path([main_app, presenter], format: 'ris') %></li>
         <li class="dropdown-item"><%= link_to t('.zotero'), hyrax.zotero_path, id: 'zoteroLink', name: 'zotero' %></li>
-        <li class="dropdown-item"><%= link_to t('.mendeley'), hyrax.mendeley_path, id: 'mendeleyLink', name: 'mendeley' %></li>
       </ul>
   </div>
 </li>

--- a/spec/features/viewing_a_publication_show_page_spec.rb
+++ b/spec/features/viewing_a_publication_show_page_spec.rb
@@ -49,7 +49,13 @@ RSpec.describe "viewing a publication show page", :clean_repo, :perform_enqueued
 
   it 'provides a citation link for RIS' do
     find('div.dropdown-toggle', text: 'Citation Management Tools').click
-    expect(page).to have_link('RIS')
+    expect(page).to have_link('Download Citation (RIS)')
+  end
+
+  it 'lacks Mendeley and Endnote citation options' do
+    find('div.dropdown-toggle', text: 'Citation Management Tools').click
+    expect(page).not_to have_link('Mendeley')
+    expect(page).not_to have_link('EndNote')
   end
 
   it('does not contain a COINS hook for Zotero') { expect(page).not_to have_css('span.Z3988') }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/6bf04308-4d83-4062-83cf-4074a85b1d44)
