### PR TITLE
Embed LibWizard form in contact page.

### DIFF
--- a/app/views/hyrax/contact_form/new.html.erb
+++ b/app/views/hyrax/contact_form/new.html.erb
@@ -1,3 +1,5 @@
+<%# Hyrax v5.x override: removes Hyrax email form and uses LibWizard embed instead. %>
+
 <div id="form_c1f0cb426fc77f8491d3b19eab369b9b"></div>
 
 <script type="text/javascript" src="https://emory.libwizard.com/form_loader.php?id=c1f0cb426fc77f8491d3b19eab369b9b&noheader=1"></script>

--- a/app/views/hyrax/contact_form/new.html.erb
+++ b/app/views/hyrax/contact_form/new.html.erb
@@ -1,0 +1,3 @@
+<div id="form_c1f0cb426fc77f8491d3b19eab369b9b"></div>
+
+<script type="text/javascript" src="https://emory.libwizard.com/form_loader.php?id=c1f0cb426fc77f8491d3b19eab369b9b&noheader=1"></script>

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -6,15 +6,15 @@
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
 
 Rails.application.config.content_security_policy do |policy|
-#   policy.default_src :self, :https
-#   policy.font_src    :self, :https, :data
-#   policy.img_src     :self, :https, :data
-#   policy.object_src  :none
-  policy.script_src  :self, 'https://emory.libwizard.com/form_loader.php?id=c1f0cb426fc77f8491d3b19eab369b9b&noheader=1'
-#   policy.style_src   :self, :https
+  #   policy.default_src :self, :https
+  #   policy.font_src    :self, :https, :data
+  #   policy.img_src     :self, :https, :data
+  #   policy.object_src  :none
+  policy.script_src :self, 'https://emory.libwizard.com/form_loader.php?id=c1f0cb426fc77f8491d3b19eab369b9b&noheader=1 https://www.googletagmanager.com/gtag/js?id=G-JJ43YGFK4G'
+  #   policy.style_src   :self, :https
 
-#   # Specify URI for violation reports
-#   # policy.report_uri "/csp-violation-report-endpoint"
+  #   # Specify URI for violation reports
+  #   # policy.report_uri "/csp-violation-report-endpoint"
 end
 
 # If you are using UJS then enable automatic nonce generation

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -5,17 +5,17 @@
 # For further information see the following documentation
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy
 
-# Rails.application.config.content_security_policy do |policy|
+Rails.application.config.content_security_policy do |policy|
 #   policy.default_src :self, :https
 #   policy.font_src    :self, :https, :data
 #   policy.img_src     :self, :https, :data
 #   policy.object_src  :none
-#   policy.script_src  :self, :https
+  policy.script_src  :self, 'https://emory.libwizard.com/form_loader.php?id=c1f0cb426fc77f8491d3b19eab369b9b&noheader=1'
 #   policy.style_src   :self, :https
 
 #   # Specify URI for violation reports
 #   # policy.report_uri "/csp-violation-report-endpoint"
-# end
+end
 
 # If you are using UJS then enable automatic nonce generation
 # Rails.application.config.content_security_policy_nonce_generator = -> request { SecureRandom.base64(16) }


### PR DESCRIPTION
- app/views/hyrax/contact_form/new.html.erb: overrides Hyrax' contact us email form.
- config/initializers/content_security_policy.rb: allows the two expected external site endpoints in CSP.