### PR TITLE
Simplifies CSP rules so that Hyrax' inline scripts are allowed.

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -10,7 +10,7 @@ Rails.application.config.content_security_policy do |policy|
   #   policy.font_src    :self, :https, :data
   #   policy.img_src     :self, :https, :data
   #   policy.object_src  :none
-  policy.script_src :self, 'https://emory.libwizard.com/form_loader.php?id=c1f0cb426fc77f8491d3b19eab369b9b&noheader=1 https://www.googletagmanager.com/gtag/js?id=G-JJ43YGFK4G'
+  policy.script_src :self, :https, :unsafe_inline
   #   policy.style_src   :self, :https
 
   #   # Specify URI for violation reports


### PR DESCRIPTION
I understand that using `unsafe-inline` is not the best practice, per this page detailing the proper way to go: https://www.writesoftwarewell.com/implement-content-security-policy-in-rails/. However, the `nonce` solution they recommend requires adding a none element to every template that utilizes an inline script. Unfortunately, Hyrax has many templates that do and it would be quite a chore to bring them into our codebase just to add a few words of code to each. 