### PR TITLE
Adds Contact Us link to a Publication's show page's Tools.

### DIFF
--- a/app/views/hyrax/base/show.html.erb
+++ b/app/views/hyrax/base/show.html.erb
@@ -1,4 +1,4 @@
-<%# Hyrax v5.0.1 Override: institutes our own layout. Starts line 7, through line 69. %>
+<%# Hyrax v5.0.1 Override: institutes our own layout. Starts line 7, through line 71. %>
 
 <% provide :page_title, @presenter.page_title %>
 
@@ -47,7 +47,12 @@
                   id: "file_download" %>
                 </li>
                 <% end %>
-
+                <li class="list-group-item direct_link">
+                  <%= link_to 'Contact Us',
+                    "https://emory.libwizard.com/id/c1f0cb426fc77f8491d3b19eab369b9b?referal_url=#{request.original_url}",
+                    target: :_blank
+                  %>
+                </li>
                 <%= render 'citations', presenter: @presenter %>
 
               </ul>

--- a/spec/features/viewing_a_publication_show_page_spec.rb
+++ b/spec/features/viewing_a_publication_show_page_spec.rb
@@ -60,6 +60,14 @@ RSpec.describe "viewing a publication show page", :clean_repo, :perform_enqueued
 
   it('does not contain a COINS hook for Zotero') { expect(page).not_to have_css('span.Z3988') }
 
+  it 'contains a Contact Us link in Tools' do
+    contact_us = find('.card.viewer-actions ul li.direct_link a', text: 'Contact Us')
+    expect(contact_us['href']).to include(
+      'https://emory.libwizard.com/id/c1f0cb426fc77f8491d3b19eab369b9b?referal_url', "/concern/publications/#{publication.id}"
+    )
+    expect(contact_us['target']).to eq('_blank')
+  end
+
   context 'when user is admin' do
     # make an admin user for testing preservation events table presence
     before do


### PR DESCRIPTION
![Contact Us In Tools](https://github.com/user-attachments/assets/f065e65f-84b7-4eb6-a029-9b4dd2e6a7a9)
