### PR TITLE
Revert "Unhinders Javascript with unsafe_eval."

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -10,7 +10,7 @@ Rails.application.config.content_security_policy do |policy|
   #   policy.font_src    :self, :https, :data
   #   policy.img_src     :self, :https, :data
   #   policy.object_src  :none
-  policy.script_src :self, :https, :unsafe_eval, :unsafe_inline
+  policy.script_src :self, :https, :unsafe_inline
   #   policy.style_src   :self, :https
 
   #   # Specify URI for violation reports


### PR DESCRIPTION
This reverts commit 6189501c448c4a3db6c6e62b039b06c885e0824a.