### PR TITLE
Corrects SAML redirect.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,7 +22,7 @@ class ApplicationController < ActionController::Base
         if AuthConfig.use_database_auth?
           redirect_to main_app.new_user_session_path, alert: exception.message
         else
-          redirect_to main_app.user_saml_omniauth_authorize_path, alert: exception.message
+          redirect_to main_app.user_saml_omniauth_authorize_path(origin: request.url), alert: exception.message
         end
       end
       wants.json { render_json_response(response_type: :unauthorized, message: json_message) }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,6 +12,10 @@ class ApplicationController < ActionController::Base
 
   protect_from_forgery with: :exception
 
+  def saml_redirect
+    respond_to { |wants| wants.html { render 'shared/saml_redirect' } }
+  end
+
   private
 
   # Hyrax v5.0.1 override: changes html redirect to our saml path
@@ -22,7 +26,7 @@ class ApplicationController < ActionController::Base
         if AuthConfig.use_database_auth?
           redirect_to main_app.new_user_session_path, alert: exception.message
         else
-          redirect_to main_app.user_saml_omniauth_authorize_path(origin: request.url), alert: exception.message
+          redirect_to main_app.saml_redirect_path(origin: request.url), alert: exception.message
         end
       end
       wants.json { render_json_response(response_type: :unauthorized, message: json_message) }

--- a/app/views/shared/saml_redirect.html.erb
+++ b/app/views/shared/saml_redirect.html.erb
@@ -1,0 +1,13 @@
+<div class="info_box">You are being redirected to Emory's sign-in page</div>
+<%= button_to "Login", main_app.user_saml_omniauth_authorize_path(origin: params['origin']), method: :post, id: 'saml_button', style: 'display: none' %>
+<script>
+  function ready(callbackFunction){
+    if(document.readyState != 'loading')
+      callbackFunction();
+    else
+      document.addEventListener("DOMContentLoaded", callbackFunction);
+  }
+  ready(() => {
+    document.getElementById('saml_button').click();
+  })
+</script>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,7 @@ Rails.application.routes.draw do
     post '/auth/saml/callback', to: 'omniauth_callbacks#saml', as: 'user_omniauth_callback'
     post '/auth/saml', to: 'omniauth_callbacks#passthru', as: 'user_omniauth_authorize'
     get 'users/sign_out', to: 'devise/sessions#destroy', as: :destroy_user_session unless AuthConfig.use_database_auth?
+    match 'saml_redirect' => 'application#saml_redirect', as: :saml_redirect, via: [:get]
   end
 
   resources :background_jobs, only: [:new, :create]


### PR DESCRIPTION
I have confirmed that Omniauth v2 doesn't endorse (for security reasons) or easily allow the `user_saml_omniauth_authorize_path` to be used with the `:get` method. I've implemented the best workaround--this actually provides end-users the error alert before they're taken to Shibboleth.

- app/controllers/application_controller.rb: defines an action that takes users to the `saml_redirect` page as well as changes the redirect to this action.
- app/views/shared/saml_redirect.html.erb: creates a very simple page with a hidden button that gets pressed at page load.
- config/routes.rb: routes the action to the template.