### PR TITLE
Converts PreservationEvent Remediation task to a job.

### DIFF
--- a/app/controllers/background_jobs_controller.rb
+++ b/app/controllers/background_jobs_controller.rb
@@ -18,6 +18,9 @@ class BackgroundJobsController < ApplicationController
       redirect_to new_background_job_path, notice: "Preservation Workflow Importer Job has started successfully."
     elsif params[:jobs] == 'publications_to_collection'
       link_unlinked_publications_to_collection
+    elsif params[:jobs] == 'preservation_event_remediation'
+      RemediateObjectsLackingPreservationEventsJob.perform_later
+      redirect_to new_background_job_path, notice: "PreservationEvent Remediation Job has started successfully."
     else
       reindex_objects_action
       redirect_to new_background_job_path, notice: "Reindex Files Job has started successfully."

--- a/app/jobs/remediate_objects_lacking_preservation_events_job.rb
+++ b/app/jobs/remediate_objects_lacking_preservation_events_job.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+require 'preservation_events'
+
+class RemediateObjectsLackingPreservationEventsJob < Hyrax::ApplicationJob
+  include PreservationEvents
+
+  def perform
+    query_service = Hyrax.query_service
+    publication_ids_lacking_events = query_service&.custom_queries
+                                                  &.find_all_object_ids_lacking_preservation_events(model: Publication)
+                                                  &.to_a&.compact&.uniq
+
+    publication_ids_lacking_events.each do |id|
+      publication = query_service.find_by(id:)
+      event_start = publication.created_at
+      user_email = publication.depositor
+
+      create_preservation_event(publication, work_creation(event_start:, user_email:))
+      create_preservation_event(publication, work_policy(event_start:, visibility: publication.visibility, user_email:))
+      Rails.logger.info("Preservation Events for Publication with ID #{id} have been remediated.")
+    end
+  end
+end

--- a/app/services/self_deposit/custom_queries/find_all_object_ids_lacking_preservation_events.rb
+++ b/app/services/self_deposit/custom_queries/find_all_object_ids_lacking_preservation_events.rb
@@ -13,7 +13,10 @@ module SelfDeposit
       # @returns [Publications#id, FileSets#id]
       def find_all_object_ids_lacking_preservation_events(model: nil)
         @model = model
-        valkyrie_objects_from_filter_query
+        solr_documents_with_filter_query
+          &.map { |doc| doc[fields_selection] }
+          &.flatten
+          &.uniq
       end
 
       # Solr query for objects with no preservation_events_tesim values.

--- a/app/views/background_jobs/new.html.erb
+++ b/app/views/background_jobs/new.html.erb
@@ -38,6 +38,13 @@
         <%= text_area_tag 'collection_id', nil, size: '60x2', placeholder: 'Collection ID. If left blank, an attempt to find the OpenEmory Collection ID will be made.' %>
       </td>
     </tr>
+    <tr>
+      <td>
+        <%= radio_button_tag :jobs, 'preservation_event_remediation', false, id: 'preservation_event_remediation' %>
+        <%= label :job_cleanup, 'Remediate Objects Lacking PreservationEvents' %>
+      </td>
+      <td>N/A</td>
+    </tr>
   </table>
   <button class="btn btn-primary" type="submit" value="Submit">Start Job</button>
 <% end %>

--- a/lib/tasks/preservation_events_remediation.rake
+++ b/lib/tasks/preservation_events_remediation.rake
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require 'preservation_events'
 
 # rubocop:disable Metrics/BlockLength
 namespace :selfdeposit do
@@ -24,21 +23,7 @@ namespace :selfdeposit do
 
     desc "Remediates Publication objects that lack PreservationEvent objects"
     task remediate_preservation_events_for_publications_lacking_them: :environment do
-      include PreservationEvents
-      query_service = Hyrax.query_service
-      publication_ids_lacking_events = query_service&.custom_queries
-                                                    &.find_all_object_ids_lacking_preservation_events(model: Publication)
-                                                    &.to_a&.compact&.uniq
-
-      publication_ids_lacking_events.each do |id|
-        publication = query_service.find_by(id:)
-        event_start = publication.created_at
-        user_email = publication.depositor
-
-        create_preservation_event(publication, work_creation(event_start:, user_email:))
-        create_preservation_event(publication, work_policy(event_start:, visibility: publication.visibility, user_email:))
-        puts "Preservation Events for Publication with ID #{id} have been remediated."
-      end
+      RemediateObjectsLackingPreservationEventsJob.perform_later
     end
 
     desc "Removes orphaned PreservationEvent objects listed in a CSV"

--- a/spec/controllers/background_jobs_controller_spec.rb
+++ b/spec/controllers/background_jobs_controller_spec.rb
@@ -42,6 +42,9 @@ RSpec.describe BackgroundJobsController, type: :controller, clean: true do
       let(:link_publications) do
         post :create, params: { jobs: 'publications_to_collection', format: 'json' }
       end
+      let(:remediate_pres_events) do
+        post :create, params: { jobs: 'preservation_event_remediation', format: 'json' }
+      end
 
       it "successfully starts a preservation workflow background job" do
         expect(preservation).to redirect_to(new_background_job_path)
@@ -52,6 +55,12 @@ RSpec.describe BackgroundJobsController, type: :controller, clean: true do
         expect(reindex).to redirect_to(new_background_job_path)
         # Needed to call out how many times the job will be enqueued.
         expect(ReindexObjectJob).to have_been_enqueued.twice
+      end
+
+      it "successfully starts a remediate PreservationEvents background job" do
+        expect(remediate_pres_events).to redirect_to(new_background_job_path)
+        # Needed to call out how many times the job will be enqueued.
+        expect(RemediateObjectsLackingPreservationEventsJob).to have_been_enqueued
       end
 
       it "avoids starting BatchAddPublicationsToCollectionJob background job when no unlinked Publications" do

--- a/spec/jobs/remediate_objects_lacking_preservation_events_job_spec.rb
+++ b/spec/jobs/remediate_objects_lacking_preservation_events_job_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+require 'rails_helper'
+require 'hyrax/specs/shared_specs/factories/administrative_sets'
+
+RSpec.describe RemediateObjectsLackingPreservationEventsJob, :clean do
+  let(:user) { FactoryBot.create(:user) }
+  let(:admin_set) { FactoryBot.valkyrie_create(:hyrax_admin_set) }
+  let(:publication) { FactoryBot.valkyrie_create(:publication, deduplication_key: '1234reet', admin_set_id: admin_set.id, depositor: user.user_key) }
+
+  before do
+    Hyrax.index_adapter.wipe!
+    publication
+  end
+
+  it "adds preservation events to publication lacking it" do
+    expect { described_class.perform_now }.to change { Hyrax.query_service.find_by(id: publication.id).preservation_events }
+  end
+end


### PR DESCRIPTION
- app/controllers/background_jobs_controller.rb: adds a new logic directive for the `RemediateObjectsLackingPreservationEventsJob`.
- app/jobs/remediate_objects_lacking_preservation_events_job.rb: swaps the task logic to a Job and reports to Rails logger instead of STDOUT.
- app/services/self_deposit/custom_queries/find_all_object_ids_lacking_preservation_events.rb: corrects the output of the query to the desired array of ID strings, not the objects themselves.
- app/views/background_jobs/new.html.erb: stubs a new table row input selector for the Background Job.
- lib/tasks/preservation_events_remediation.rake: replaces the rake task logic with a call to the new BGJob.
- spec/controllers/background_jobs_controller_spec.rb: creates testing of the new items.