### PR TITLE
Removes commands breaking CodeClimate reporting.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,11 +135,11 @@ jobs:
           command: |
             curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
             chmod +x ./cc-test-reporter
-      - run:
-          name: Upload Coverage
-          command: |
-            ./cc-test-reporter sum-coverage --output='/tmp/codeclimate/summed_coverage.json' /tmp/codeclimate/codeclimate.*.json
-            ./cc-test-reporter upload-coverage --input='/tmp/codeclimate/summed_coverage.json'
+      # - run:
+      #     name: Upload Coverage
+      #     command: |
+      #       ./cc-test-reporter sum-coverage --output='/tmp/codeclimate/summed_coverage.json' /tmp/codeclimate/codeclimate.*.json
+      #       ./cc-test-reporter upload-coverage --input='/tmp/codeclimate/summed_coverage.json'
 
 workflows:
   version: 2


### PR DESCRIPTION
<img width="697" height="381" alt="image" src="https://github.com/user-attachments/assets/75245b1d-8c44-4923-86c2-855ead9775de" />

We eventually have to migrate to the replacement Qlty, but I don't want to mess with that until @rotated8 gets back from vacation.